### PR TITLE
Generate `withField` methods in Scala generator

### DIFF
--- a/library/src/test/scala/ScalaCodeGenSpec.scala
+++ b/library/src/test/scala/ScalaCodeGenSpec.scala
@@ -78,6 +78,9 @@ class ScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |  override def toString: String = {
         |    "childRecord(" +  + ")"
         |  }
+        |  private[this] def copy(): childRecord = {
+        |    new childRecord()
+        |  }
         |}
         |
         |object childRecord {
@@ -137,6 +140,12 @@ class ScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |  override def toString: String = {
         |    "simpleRecordExample(" + field + ")"
         |  }
+        |  private[this] def copy(field: type = field): simpleRecordExample = {
+        |    new simpleRecordExample(field)
+        |  }
+        |  def withField(field: type): simpleRecordExample = {
+        |    copy(field = field)
+        |  }
         |}
         |object simpleRecordExample {
         |  def apply(field: type): simpleRecordExample = new simpleRecordExample(field)
@@ -161,6 +170,12 @@ class ScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |  }
         |  override def toString: String = {
         |    "growableAddOneField(" + field + ")"
+        |  }
+        |  private[this] def copy(field: Int = field): growableAddOneField = {
+        |    new growableAddOneField(field)
+        |  }
+        |  def withField(field: Int): growableAddOneField = {
+        |    copy(field = field)
         |  }
         |}
         |object growableAddOneField {
@@ -197,6 +212,21 @@ class ScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |  override def toString: String = {
         |    super.toString // Avoid evaluating lazy members in toString to avoid circularity.
         |  }
+        |  private[this] def copy(simpleInteger: Int = simpleInteger, lazyInteger: => Int = lazyInteger, arrayInteger: Array[Int] = arrayInteger, lazyArrayInteger: => Array[Int] = lazyArrayInteger): primitiveTypesExample = {
+        |    new primitiveTypesExample(simpleInteger, lazyInteger, arrayInteger, lazyArrayInteger)
+        |  }
+        |  def withSimpleInteger(simpleInteger: Int): primitiveTypesExample = {
+        |    copy(simpleInteger = simpleInteger)
+        |  }
+        |  def withLazyInteger(lazyInteger: => Int): primitiveTypesExample = {
+        |    copy(lazyInteger = lazyInteger)
+        |  }
+        |  def withArrayInteger(arrayInteger: Array[Int]): primitiveTypesExample = {
+        |    copy(arrayInteger = arrayInteger)
+        |  }
+        |  def withLazyArrayInteger(lazyArrayInteger: => Array[Int]): primitiveTypesExample = {
+        |    copy(lazyArrayInteger = lazyArrayInteger)
+        |  }
         |}
         |
         |object primitiveTypesExample {
@@ -226,6 +256,15 @@ class ScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |  }
         |  override def toString: String = {
         |    "primitiveTypesNoLazyExample(" + simpleInteger + ", " + arrayInteger + ")"
+        |  }
+        |  private[this] def copy(simpleInteger: Int = simpleInteger, arrayInteger: Array[Int] = arrayInteger): primitiveTypesNoLazyExample = {
+        |    new primitiveTypesNoLazyExample(simpleInteger, arrayInteger)
+        |  }
+        |  def withSimpleInteger(simpleInteger: Int): primitiveTypesNoLazyExample = {
+        |    copy(simpleInteger = simpleInteger)
+        |  }
+        |  def withArrayInteger(arrayInteger: Array[Int]): primitiveTypesNoLazyExample = {
+        |    copy(arrayInteger = arrayInteger)
         |  }
         |}
         |

--- a/library/src/test/scala/SchemaExample.scala
+++ b/library/src/test/scala/SchemaExample.scala
@@ -320,6 +320,15 @@ object NewSchema {
       |  override def toString: String = {
       |    super.toString // Avoid evaluating lazy members in toString to avoid circularity.
       |  }
+      |  private[this] def copy(message: => String = message, header: GreetingHeader = header): SimpleGreeting = {
+      |    new SimpleGreeting(message, header)
+      |  }
+      |  def withMessage(message: => String): SimpleGreeting = {
+      |    copy(message = message)
+      |  }
+      |  def withHeader(header: GreetingHeader): SimpleGreeting = {
+      |    copy(header = header)
+      |  }
       |}
       |
       |object SimpleGreeting {
@@ -344,6 +353,18 @@ object NewSchema {
       |  }
       |  override def toString: String = {
       |    super.toString // Avoid evaluating lazy members in toString to avoid circularity.
+      |  }
+      |  private[this] def copy(attachments: Array[java.io.File] = attachments, message: => String = message, header: GreetingHeader = header): GreetingWithAttachments = {
+      |    new GreetingWithAttachments(attachments, message, header)
+      |  }
+      |  def withAttachments(attachments: Array[java.io.File]): GreetingWithAttachments = {
+      |    copy(attachments = attachments)
+      |  }
+      |  def withMessage(message: => String): GreetingWithAttachments = {
+      |    copy(message = message)
+      |  }
+      |  def withHeader(header: GreetingHeader): GreetingWithAttachments = {
+      |    copy(header = header)
       |  }
       |}
       |
@@ -372,6 +393,18 @@ object NewSchema {
       |  }
       |  override def toString: String = {
       |    super.toString // Avoid evaluating lazy members in toString to avoid circularity.
+      |  }
+      |  private[this] def copy(created: => java.util.Date = created, priority: PriorityLevel = priority, author: String = author): GreetingHeader = {
+      |    new GreetingHeader(created, priority, author)
+      |  }
+      |  def withCreated(created: => java.util.Date): GreetingHeader = {
+      |    copy(created = created)
+      |  }
+      |  def withPriority(priority: PriorityLevel): GreetingHeader = {
+      |    copy(priority = priority)
+      |  }
+      |  def withAuthor(author: String): GreetingHeader = {
+      |    copy(author = author)
       |  }
       |}
       |


### PR DESCRIPTION
For instance for the following schema:
```json
{
  "name": "simpleRecordExample",
  "type": "record",
  "target": "Scala",
  "fields": [
    {
      "name": "foo",
      "type": "type"
    }
  ]
}
```

It will generate the following Scala code:

```scala
final class simpleRecordExample(
  val foo: type)  {
  
  override def equals(o: Any): Boolean = o match {
    case x: simpleRecordExample => (this.foo == x.foo)
    case _ => false
  }
  override def hashCode: Int = {
    37 * (17 + foo.##)
  }
  override def toString: String = {
    "simpleRecordExample(" + foo + ")"
  }
  private[this] def copy(foo: type = foo): simpleRecordExample = {
    new simpleRecordExample(foo)
  }
  def withFoo(foo: type): simpleRecordExample = {
    copy(foo = foo)
  }
}
object simpleRecordExample {
  def apply(foo: type): simpleRecordExample = new simpleRecordExample(foo)
}
```