### PR TITLE
Publish to bintray

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2015 Typesafe Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,11 @@ lazy val commonSettings = Seq(
     organization in ThisBuild := "org.scala-sbt",
     version in ThisBuild := "0.1.0-SNAPSHOT",
     crossScalaVersions := Seq("2.11.6", "2.10.5"),
-    scalaVersion := "2.10.5"
+    scalaVersion := "2.10.5",
+    licenses += ("Apache-2.0", url("https://github.com/sbt/sbt-datatype/blob/master/LICENSE")),
+    bintrayOrganization := Some("sbt"),
+    bintrayRepository := "sbt-plugin-releases",
+    bintrayVcsUrl := Some("git@github.com:sbt/sbt-datatype.git")
   )
 
 lazy val root = (project in file(".")).
@@ -16,6 +20,7 @@ lazy val plugin = (project in file("plugin")).
   settings(
     sbtPlugin := true,
     name := "datatype-plugin",
+    description := "sbt plugin to generate growable datatypes.",
     ScriptedPlugin.scriptedSettings,
     scriptedLaunchOpts := { scriptedLaunchOpts.value ++
       Seq("-Xmx1024M", "-XX:MaxPermSize=256M", "-Dplugin.version=" + version.value)
@@ -28,5 +33,6 @@ lazy val library = project.
   settings(commonSettings).
   settings(
     name := "datatype",
+    description := "Code generation library to generate growable datatypes.",
     libraryDependencies ++= jsonDependencies ++ Seq(specs2 % Test)
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")


### PR DESCRIPTION
~~I've merged the two previous subprojects (previously library and plugin) into only one project.~~

~~I've added the plugin and configuration to publish it to Bintray directly in `sbt/sbt-plugin-releases` repository.~~

~~**I've published this as v0.0.1 on Bintray.** Hope that's okay.~~

I've added a license (BSD 3 clauses, the same as sbt/sbt I think).
Both the plugin and the library are configured to be published in `sbt/sbt-plugin-release`