### PR TITLE
Declare `library` project as sbt plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,7 @@ lazy val plugin = (project in file("plugin")).
 lazy val library = project.
   settings(commonSettings).
   settings(
+    sbtPlugin := true,
     name := "datatype",
     description := "Code generation library to generate growable datatypes.",
     libraryDependencies ++= jsonDependencies ++ Seq(specs2 % Test)


### PR DESCRIPTION
Otherwise the dependency from `plugin` to `library` won't be resolved.

I've released this as datatype-plugin and datatype 0.0.2 on bintray.