### PR TITLE
Support for multiline doc comment

### DIFF
--- a/library/src/main/scala/Indentation.scala
+++ b/library/src/main/scala/Indentation.scala
@@ -6,7 +6,7 @@ import scala.compat.Platform.EOL
  * Implementation of a string buffer which takes care of indentation (according to `augmentIndentTrigger`,
  * `augmentIndentAfterTrigger`, `reduceIndentTrigger` and `reduceIndentAfterTrigger`) as text is added.
  */
-class IndentationAwareBuffer(val config: IndentationConfiguration, private var level: Int = 0) {
+class IndentationAwareBuffer(val config: IndentationConfiguration, private var level: Int = 0, private var inJavadoc: Boolean = false) {
   private val buffer: StringBuilder = new StringBuilder
 
   /** Add all the lines of `it` to the buffer. */
@@ -20,7 +20,9 @@ class IndentationAwareBuffer(val config: IndentationConfiguration, private var l
     val clean = s.trim
     if (config.augmentIndentTrigger(clean)) level += 1
     if (config.reduceIndentTrigger(clean)) level = 0 max (level - 1)
-    buffer append (config.indentElement * level + clean + EOL)
+    buffer append (config.indentElement * level + (if (inJavadoc) s else clean) + EOL)
+    if (config.exitMultilineJavadoc(clean)) inJavadoc = false
+    if (config.enterMultilineJavadoc(clean)) inJavadoc = true
     if (config.augmentIndentAfterTrigger(clean)) level += 1
     if (config.reduceIndentAfterTrigger(clean)) level = 0 max (level - 1)
   }
@@ -38,6 +40,12 @@ abstract class IndentationConfiguration {
 
   /** When this predicate holds for `s`, next lines should have one less level of indentation. */
   def reduceIndentAfterTrigger(s: String): Boolean = false
+
+  /** When this predicate holds for `s`, the next lines will be treated as multiline Javadoc. */
+  def enterMultilineJavadoc(s: String): Boolean = false
+
+  /** When this predicate holds for `s`, the next lines will no longer be treated as multiline Javadoc. */
+  def exitMultilineJavadoc(s: String): Boolean = false
 
   /** Element of indentation. Prepended at each indented lines, as many times as there are indentation levels. */
   def indentElement: String = ""

--- a/library/src/main/scala/JavaCodeGen.scala
+++ b/library/src/main/scala/JavaCodeGen.scala
@@ -12,6 +12,8 @@ object JavaCodeGen extends CodeGenerator {
     override val indentElement = "    "
     override def augmentIndentAfterTrigger(s: String) = s endsWith "{"
     override def reduceIndentTrigger(s: String) = s startsWith "}"
+    override def enterMultilineJavadoc(s: String) = s == "/**"
+    override def exitMultilineJavadoc(s: String) = s == "*/"
   }
 
   override def generate(s: Schema): Map[File, String] =
@@ -73,7 +75,14 @@ object JavaCodeGen extends CodeGenerator {
     Map(genFile(e) -> code)
   }
 
-  private def genDoc(doc: Option[String]) = doc map (d => s"/** $d */") getOrElse ""
+  private def genDoc(doc: Option[List[String]]) = doc map {
+    case l :: Nil => s"/** $l */"
+    case lines =>
+      val doc = lines map (l => s" * $l") mkString EOL
+      s"""/**
+         |$doc
+         | */""".stripMargin
+  } getOrElse ""
 
   private def genFile(d: Definition) = {
     val fileName = d.name + ".java"

--- a/library/src/test/scala/SchemaExample.scala
+++ b/library/src/test/scala/SchemaExample.scala
@@ -198,7 +198,10 @@ object NewSchema {
       "fields": [
         {
           "name": "message",
-          "doc": "The message of the Greeting",
+          "doc": [
+            "The message of the Greeting",
+            "This is a multiline doc comment"
+          ],
           "type": "lazy String"
         },
         {
@@ -290,7 +293,10 @@ object NewSchema {
       |  val header: GreetingHeader) extends Serializable {
       |  def this(message: => String) = this(message, new GreetingHeader(new java.util.Date(), "Unknown"))
       |
-      |  /** The message of the Greeting */
+      |  /**
+      |   * The message of the Greeting
+      |   * This is a multiline doc comment
+      |   */
       |  lazy val message: String = _message
       |  override def equals(o: Any): Boolean = o match {
       |    case x: Greetings => super.equals(o) // We have lazy members, so use object identity to avoid circularity.
@@ -527,7 +533,10 @@ object NewSchema {
           |/** A greeting protocol */
           |public abstract class Greetings implements java.io.Serializable {
           |
-          |    /** The message of the Greeting */
+          |    /**
+          |     * The message of the Greeting
+          |     * This is a multiline doc comment
+          |     */
           |    private Lazy<String> message;
           |    /** The header of the Greeting */
           |    private GreetingHeader header;
@@ -604,5 +613,15 @@ object NewSchema {
     }
   ]
 }""".stripMargin
+
+  val multiLineDocExample =
+    """{
+      |  "name": "multiLineDocField",
+      |  "type": "int",
+      |  "doc": [
+      |    "A field whose documentation",
+      |    "spans over multiple lines"
+      |  ]
+      |}""".stripMargin
 
 }

--- a/library/src/test/scala/SchemaSpec.scala
+++ b/library/src/test/scala/SchemaSpec.scala
@@ -34,6 +34,7 @@ class SchemaSpec extends Specification {
 
     Field.parse should
       parse                                      $fieldParse
+      parse multiline doc comments               $multiLineDoc
 
     TpeRef.apply should
       parse simple types                         $tpeRefParseSimple
@@ -162,7 +163,7 @@ class SchemaSpec extends Specification {
         namespace must_== None
         doc must_== Some("Example of simple enumeration")
         values must haveSize(2)
-        values(0) must_== EnumerationValue("first", Some("First type"))
+        values(0) must_== EnumerationValue("first", Some(List("First type")))
         values(1) must_== EnumerationValue("second", None)
     }
   }
@@ -212,6 +213,18 @@ class SchemaSpec extends Specification {
         name must_== "lazyArrayTpeRefExample"
         lzy must_== true
         repeated must_== true
+    }
+  }
+
+  def multiLineDoc = {
+    Field parse multiLineDocExample match {
+      case Field(name, doc, tpe, since, default) =>
+        name must_== "multiLineDocField"
+        doc must_== Some(List("A field whose documentation",
+                              "spans over multiple lines"))
+
+      case _ =>
+        true must_== false
     }
   }
 


### PR DESCRIPTION
The Javadoc in the schema definition can now optionally span over
multiple lines. To write multiline Javadoc, it suffices to set the
property `doc` of any node to an array containing all the lines.
Single-line Javadoc can still be written using the previous style.

This will be useful when we will start to port other classes to sbt-datatype (e.g. `UpdateOptions`)