### PR TITLE
Generate abstract methods in protocols

### DIFF
--- a/library/src/test/scala/CodeGenSpec.scala
+++ b/library/src/test/scala/CodeGenSpec.scala
@@ -23,6 +23,7 @@ abstract class GCodeGenSpec(language: String) extends Specification {
       generate a simple protocol                 $protocolGenerateSimple
       generate a simple protocol with one child  $protocolGenerateOneChild
       generate nested protocols                  $protocolGenerateNested
+      generate abstract methods                  $protocolGenerateAbstractMethods
 
     generate(Record) should
       generate a simple record                   $recordGenerateSimple
@@ -40,6 +41,7 @@ abstract class GCodeGenSpec(language: String) extends Specification {
   def protocolGenerateSimple: MatchResult[_]
   def protocolGenerateOneChild: MatchResult[_]
   def protocolGenerateNested: MatchResult[_]
+  def protocolGenerateAbstractMethods: MatchResult[_]
   def recordGenerateSimple: MatchResult[_]
   def schemaGenerateComplete: MatchResult[_]
   def schemaGenerateCompletePlusIndent: MatchResult[_]

--- a/library/src/test/scala/JavaCodeGenSpec.scala
+++ b/library/src/test/scala/JavaCodeGenSpec.scala
@@ -166,6 +166,52 @@ class JavaCodeGenSpec extends GCodeGenSpec("Java") {
     )
   }
 
+  override def protocolGenerateAbstractMethods = {
+    val schema = Schema parse generateArgDocExample
+    val code = new JavaCodeGen("com.example.MyLazy") generate schema
+
+    code mapValues (_.withoutEmptyLines) must containTheSameElementsAs(
+      Map(
+        new File("generateArgDocExample.java") ->
+          """public abstract class generateArgDocExample implements java.io.Serializable {
+            |    /** I'm a field. */
+            |    private int field;
+            |    public generateArgDocExample(int _field) {
+            |        super();
+            |        field = _field;
+            |    }
+            |    public int field() {
+            |        return this.field;
+            |    }
+            |    /**
+            |     * A very simple example of abstract method.
+            |     * Abstract methods can only appear in protocol definitions.
+            |     * @param arg0 The first argument of the method.
+            |                   Make sure it is awesome.
+            |     * @param arg1 This argument is not important, so it gets single line doc.
+            |     */
+            |    public abstract int[] methodExample(com.example.MyLazy<int[]> arg0,boolean arg1);
+            |    public boolean equals(Object obj) {
+            |        if (this == obj) {
+            |            return true;
+            |        } else if (!(obj instanceof generateArgDocExample)) {
+            |            return false;
+            |        } else {
+            |            generateArgDocExample o = (generateArgDocExample)obj;
+            |            return (field() == o.field());
+            |        }
+            |    }
+            |    public int hashCode() {
+            |        return 37 * (17 + (new Integer(field())).hashCode());
+            |    }
+            |    public String toString() {
+            |        return "generateArgDocExample("  + "field: " + field() + ")";
+            |    }
+            |}""".stripMargin.withoutEmptyLines
+      ).toList
+    )
+  }
+
   override def recordGenerateSimple = {
     val record = Record parse simpleRecordExample
     val code = new JavaCodeGen("com.example.MyLazy") generate record

--- a/library/src/test/scala/ScalaCodeGenSpec.scala
+++ b/library/src/test/scala/ScalaCodeGenSpec.scala
@@ -121,6 +121,36 @@ class ScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |}""".stripMargin.unindent)
   }
 
+  override def protocolGenerateAbstractMethods = {
+    val schema = Schema parse generateArgDocExample
+    val code = new ScalaCodeGen(genFileName, sealProtocols = false) generate schema
+
+    code.head._2.withoutEmptyLines must containTheSameElementsAs(
+      """abstract class generateArgDocExample(
+        |  /** I'm a field. */
+        |  val field: Int) extends Serializable {
+        |  /**
+        |   * A very simple example of abstract method.
+        |   * Abstract methods can only appear in protocol definitions.
+        |   * @param arg0 The first argument of the method.
+        |                 Make sure it is awesome.
+        |   * @param arg1 This argument is not important, so it gets single line doc.
+        |   */
+        |  def methodExample(arg0: => Array[Int], arg1: Boolean): Array[Int]
+        |  override def equals(o: Any): Boolean = o match {
+        |    case x: generateArgDocExample => (this.field == x.field)
+        |    case _ => false
+        |  }
+        |  override def hashCode: Int = {
+        |    37 * (17 + field.##)
+        |  }
+        |  override def toString: String = {
+        |    "generateArgDocExample(" + field + ")"
+        |  }
+        |}""".stripMargin.withoutEmptyLines)
+
+  }
+
   override def recordGenerateSimple = {
     val gen = new ScalaCodeGen(genFileName, sealProtocols = true)
     val record = Record parse simpleRecordExample

--- a/library/src/test/scala/SchemaExample.scala
+++ b/library/src/test/scala/SchemaExample.scala
@@ -131,6 +131,18 @@ object NewSchema {
   "default": "2 + 2"
 }"""
 
+  val abstractMethodExample = """{
+  "name": "abstractMethodExample",
+  "doc": "Example of abstract method",
+  "type": "type",
+  "args": [
+    {
+      "name": "arg0",
+      "type": "type2"
+    }
+  ]
+}"""
+
   val simpleTpeRefExample = "simpleTpeRefExample"
   val lazyTpeRefExample = "lazy lazyTpeRefExample"
   val arrayTpeRefExample = "arrayTpeRefExample*"
@@ -184,7 +196,47 @@ object NewSchema {
   ]
 }"""
 
-
+  val generateArgDocExample = """{
+  "types": [
+    {
+      "name": "generateArgDocExample",
+      "target": "Scala",
+      "type": "protocol",
+      "fields": [
+        {
+          "name": "field",
+          "type": "int",
+          "doc": "I'm a field."
+        }
+      ],
+      "methods": [
+        {
+          "name": "methodExample",
+          "doc": [
+            "A very simple example of abstract method.",
+            "Abstract methods can only appear in protocol definitions."
+          ],
+          "type": "int*",
+          "args": [
+            {
+              "name": "arg0",
+              "type": "lazy int*",
+              "doc": [
+                "The first argument of the method.",
+                "Make sure it is awesome."
+              ]
+            },
+            {
+              "name": "arg1",
+              "type": "boolean",
+              "doc": "This argument is not important, so it gets single line doc."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}"""
 
   val completeExample = """{
   "types": [

--- a/library/src/test/scala/SchemaSpec.scala
+++ b/library/src/test/scala/SchemaSpec.scala
@@ -60,12 +60,13 @@ class SchemaSpec extends Specification {
 
   def definitionParseProtocol = {
     Definition parse emptyProtocolExample match {
-      case Protocol(name, target, namespace, _, doc, fields, children) =>
+      case Protocol(name, target, namespace, _, doc, fields, abstractMethods, children) =>
         name must_== "emptyProtocolExample"
         target must_== "Scala"
         namespace must_== None
         doc must_== None
         fields must haveSize(0)
+        abstractMethods must haveSize(0)
         children must haveSize(0)
 
       case _ =>
@@ -106,40 +107,43 @@ class SchemaSpec extends Specification {
 
   def protocolParseSimple = {
     Protocol parse simpleProtocolExample match {
-      case Protocol(name, target, namespace, doc, _, fields, children) =>
+      case Protocol(name, target, namespace, doc, _, fields, abstractMethods, children) =>
         name must_== "simpleProtocolExample"
         target must_== "Scala"
         namespace must_== None
         doc must_== Some("example of simple protocol")
         fields must haveSize(1)
-        fields(0) must_== Field("field", None, TpeRef("type", false, false), Field.emptyVersion, None)
+        fields(0) must_== Field("field", Nil, TpeRef("type", false, false), Field.emptyVersion, None)
+        abstractMethods must haveSize(0)
         children must haveSize(0)
     }
   }
 
   def protocolParseOneChild = {
     Protocol parse oneChildProtocolExample match {
-      case Protocol(name, target, namespace, doc, _, fields, children) =>
+      case Protocol(name, target, namespace, doc, _, fields, abstractMethods, children) =>
         name must_== "oneChildProtocolExample"
         target must_== "Scala"
         namespace must_== None
         doc must_== Some("example of protocol")
         fields must haveSize(0)
+        abstractMethods must haveSize(0)
         children must haveSize(1)
-        children(0) must_== Record("childRecord", "Scala", None, VersionNumber("0.0.0"), None, Nil)
+        children(0) must_== Record("childRecord", "Scala", None, VersionNumber("0.0.0"), Nil, Nil)
     }
   }
 
   def protocolParseNested = {
     Protocol parse nestedProtocolExample match {
-      case Protocol(name, target, namespace, doc, _, fields, children) =>
+      case Protocol(name, target, namespace, doc, _, fields, abstractMethods, children) =>
         name must_== "nestedProtocolExample"
         target must_== "Scala"
         namespace must_== None
         doc must_== Some("example of nested protocols")
         fields must haveSize(0)
+        abstractMethods must haveSize(0)
         children must haveSize(1)
-        children(0) must_== Protocol("nestedProtocol", "Scala", None, VersionNumber("0.0.0"), None, Nil, Nil)
+        children(0) must_== Protocol("nestedProtocol", "Scala", None, VersionNumber("0.0.0"), Nil, Nil, Nil, Nil)
     }
   }
 
@@ -151,7 +155,7 @@ class SchemaSpec extends Specification {
         namespace must_== None
         doc must_== Some("Example of simple record")
         fields must haveSize(1)
-        fields(0) must_== Field("field", None, TpeRef("type", false, false), Field.emptyVersion, None)
+        fields(0) must_== Field("field", Nil, TpeRef("type", false, false), Field.emptyVersion, None)
     }
   }
 
@@ -163,8 +167,8 @@ class SchemaSpec extends Specification {
         namespace must_== None
         doc must_== Some("Example of simple enumeration")
         values must haveSize(2)
-        values(0) must_== EnumerationValue("first", Some(List("First type")))
-        values(1) must_== EnumerationValue("second", None)
+        values(0) must_== EnumerationValue("first", List("First type"))
+        values(1) must_== EnumerationValue("second", Nil)
     }
   }
 
@@ -178,6 +182,16 @@ class SchemaSpec extends Specification {
         default must_== Some("2 + 2")
     }
 
+  }
+
+  def abstractMethodParse = {
+    AbstractMethod parse abstractMethodExample match {
+      case AbstractMethod(name, doc, retTpe, args) =>
+        name must_== "abstractMethodExample"
+        doc must_== "Example of abstract method"
+        retTpe must_== TpeRef("type", false, false)
+        args must_== List(Arg("arg0", Nil, TpeRef("type2", false, false)))
+    }
   }
 
   def tpeRefParseSimple = {
@@ -220,8 +234,8 @@ class SchemaSpec extends Specification {
     Field parse multiLineDocExample match {
       case Field(name, doc, tpe, since, default) =>
         name must_== "multiLineDocField"
-        doc must_== Some(List("A field whose documentation",
-                              "spans over multiple lines"))
+        doc must_== List("A field whose documentation",
+                              "spans over multiple lines")
 
       case _ =>
         true must_== false


### PR DESCRIPTION
It turns out that adding a new abstract method to an abstract class
doesn't break binary compatibility. The classes that extend the abstract
class will still be loaded correctly by even if they do not implement
some methods of their base class.