### PR TITLE
Full protocol improvements

### DIFF
--- a/library/src/test/scala/CodecCodeGenSpec.scala
+++ b/library/src/test/scala/CodecCodeGenSpec.scala
@@ -23,7 +23,7 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
   val codecParents = Nil
   val genFileName = (_: Definition) => outputFile
   val instantiateJavaLazy = (s: String) => s"mkLazy($s)"
-  val formatsForType = CodecCodeGen.formatsForType
+  val formatsForType: TpeRef => List[String] = CodecCodeGen.formatsForType
 
   override def enumerationGenerateSimple = {
     val gen = new CodecCodeGen(genFileName, protocolName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
@@ -32,7 +32,7 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
 
     code.head._2.unindent must containTheSameElementsAs(
       """import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
-        |trait simpleEnumerationExampleFormats { self: sjsonnew.BasicJsonProtocol =>
+        |trait SimpleEnumerationExampleFormats { self: sjsonnew.BasicJsonProtocol =>
         |  implicit lazy val simpleEnumerationExampleFormat: JsonFormat[simpleEnumerationExample] = new JsonFormat[simpleEnumerationExample] {
         |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): simpleEnumerationExample = {
         |      jsOpt match {
@@ -64,7 +64,7 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
 
     code.head._2.unindent must containTheSameElementsAs(
       """import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
-        |trait simpleProtocolExampleFormats {
+        |trait SimpleProtocolExampleFormats {
         |  implicit lazy val simpleProtocolExampleFormat: JsonFormat[simpleProtocolExample] = new JsonFormat[simpleProtocolExample] {
         |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): simpleProtocolExample = {
         |      deserializationError("No known implementation of simpleProtocolExample.")
@@ -83,11 +83,11 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
 
     code.head._2.unindent must containTheSameElementsAs(
       """import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
-        |trait oneChildProtocolExampleFormats { self: sjsonnew.BasicJsonProtocol with _root_.childRecordFormats =>
+        |trait OneChildProtocolExampleFormats { self: _root_.ChildRecordFormats with sjsonnew.BasicJsonProtocol =>
         |  implicit lazy val oneChildProtocolExampleFormat: JsonFormat[oneChildProtocolExample] = unionFormat1[oneChildProtocolExample, _root_.childRecord]
         |}
         |import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
-        |trait childRecordFormats {
+        |trait ChildRecordFormats {
         |  implicit lazy val childRecordFormat: JsonFormat[childRecord] = new JsonFormat[childRecord] {
         |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): childRecord = {
         |      jsOpt match {
@@ -114,11 +114,11 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
 
     code.head._2.unindent must containTheSameElementsAs(
       """import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
-        |trait nestedProtocolExampleFormats { self: sjsonnew.BasicJsonProtocol with _root_.nestedProtocolFormats =>
+        |trait NestedProtocolExampleFormats { self: _root_.NestedProtocolFormats with sjsonnew.BasicJsonProtocol =>
         |  implicit lazy val nestedProtocolExampleFormat: JsonFormat[nestedProtocolExample] = unionFormat1[nestedProtocolExample, _root_.nestedProtocol]
         |}
         |import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
-        |trait nestedProtocolFormats {
+        |trait NestedProtocolFormats {
         |  implicit lazy val nestedProtocolFormat: JsonFormat[nestedProtocol] = new JsonFormat[nestedProtocol] {
         |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): nestedProtocol = {
         |      deserializationError("No known implementation of nestedProtocol.")
@@ -137,7 +137,7 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
 
     code.head._2.unindent must containTheSameElementsAs(
       """import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
-        |trait generateArgDocExampleFormats {
+        |trait GenerateArgDocExampleFormats {
         |  implicit lazy val generateArgDocExampleFormat: JsonFormat[generateArgDocExample] = new JsonFormat[generateArgDocExample] {
         |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): generateArgDocExample = {
         |      deserializationError("No known implementation of generateArgDocExample.")
@@ -156,7 +156,7 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
 
     code.head._2.unindent must containTheSameElementsAs(
       """import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
-        |trait simpleRecordExampleFormats { self: sjsonnew.BasicJsonProtocol =>
+        |trait SimpleRecordExampleFormats { self: sjsonnew.BasicJsonProtocol =>
         |  implicit lazy val simpleRecordExampleFormat: JsonFormat[simpleRecordExample] = new JsonFormat[simpleRecordExample] {
         |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): simpleRecordExample = {
         |      jsOpt match {
@@ -185,7 +185,7 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
 
     code.head._2.unindent must containTheSameElementsAs(
       """import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
-        |trait growableAddOneFieldFormats { self: sjsonnew.BasicJsonProtocol =>
+        |trait GrowableAddOneFieldFormats { self: sjsonnew.BasicJsonProtocol =>
         |  implicit lazy val growableAddOneFieldFormat: JsonFormat[growableAddOneField] = new JsonFormat[growableAddOneField] {
         |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): growableAddOneField = {
         |      jsOpt match {
@@ -214,7 +214,7 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
 
     code.head._2.unindent must containTheSameElementsAs(
       """import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
-        |trait primitiveTypesExampleFormats { self: sjsonnew.BasicJsonProtocol =>
+        |trait PrimitiveTypesExampleFormats { self: sjsonnew.BasicJsonProtocol =>
         |  implicit lazy val primitiveTypesExampleFormat: JsonFormat[primitiveTypesExample] = new JsonFormat[primitiveTypesExample] {
         |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): primitiveTypesExample = {
         |      jsOpt match {
@@ -250,7 +250,7 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
 
     code.head._2.unindent must containTheSameElementsAs(
       """import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
-        |trait primitiveTypesNoLazyExampleFormats { self: sjsonnew.BasicJsonProtocol =>
+        |trait PrimitiveTypesNoLazyExampleFormats { self: sjsonnew.BasicJsonProtocol =>
         |  implicit lazy val primitiveTypesNoLazyExampleFormat: JsonFormat[primitiveTypesNoLazyExample] = new JsonFormat[primitiveTypesNoLazyExample] {
         |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): primitiveTypesNoLazyExample = {
         |      jsOpt match {

--- a/library/src/test/scala/CodecCodeGenSpec.scala
+++ b/library/src/test/scala/CodecCodeGenSpec.scala
@@ -18,7 +18,7 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
 
 
   val outputFile = new File("output.scala")
-  val codecName = "Codec"
+  val protocolName = None
   val codecNamespace = None
   val codecParents = Nil
   val genFileName = (_: Definition) => outputFile
@@ -26,7 +26,7 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
   val formatsForType = CodecCodeGen.formatsForType
 
   override def enumerationGenerateSimple = {
-    val gen = new CodecCodeGen(genFileName, codecName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
+    val gen = new CodecCodeGen(genFileName, protocolName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
     val enumeration = Enumeration parse simpleEnumerationExample
     val code = gen generate enumeration
 
@@ -54,13 +54,11 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
         |      builder.writeString(str)
         |    }
         |  }
-        |}
-        |trait Codec { self: _root_.simpleEnumerationExampleFormats with sjsonnew.BasicJsonProtocol => }
-        |object Codec extends Codec with _root_.simpleEnumerationExampleFormats with sjsonnew.BasicJsonProtocol""".stripMargin.unindent)
+        |}""".stripMargin.unindent)
   }
 
   override def protocolGenerateSimple = {
-    val gen = new CodecCodeGen(genFileName, codecName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
+    val gen = new CodecCodeGen(genFileName, protocolName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
     val protocol = Interface parse simpleProtocolExample
     val code = gen generate protocol
 
@@ -75,13 +73,11 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
         |      serializationError("No known implementation of simpleProtocolExample.")
         |    }
         |  }
-        |}
-        |trait Codec { self: _root_.simpleProtocolExampleFormats with sjsonnew.BasicJsonProtocol with _root_.typeFormats => }
-        |object Codec extends Codec with _root_.simpleProtocolExampleFormats with sjsonnew.BasicJsonProtocol with _root_.typeFormats""".stripMargin.unindent)
+        |}""".stripMargin.unindent)
   }
 
   override def protocolGenerateOneChild = {
-    val gen = new CodecCodeGen(genFileName, codecName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
+    val gen = new CodecCodeGen(genFileName, protocolName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
     val protocol = Interface parse oneChildProtocolExample
     val code = gen generate protocol
 
@@ -108,13 +104,11 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
         |      builder.endObject()
         |    }
         |  }
-        |}
-        |trait Codec { self: _root_.oneChildProtocolExampleFormats with sjsonnew.BasicJsonProtocol with _root_.childRecordFormats => }
-        |object Codec extends Codec with _root_.oneChildProtocolExampleFormats with sjsonnew.BasicJsonProtocol with _root_.childRecordFormats""".stripMargin.unindent)
+        |}""".stripMargin.unindent)
   }
 
   override def protocolGenerateNested = {
-    val gen = new CodecCodeGen(genFileName, codecName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
+    val gen = new CodecCodeGen(genFileName, protocolName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
     val protocol = Interface parse nestedProtocolExample
     val code = gen generate protocol
 
@@ -133,13 +127,11 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
         |      serializationError("No known implementation of nestedProtocol.")
         |    }
         |  }
-        |}
-        |trait Codec { self: _root_.nestedProtocolExampleFormats with sjsonnew.BasicJsonProtocol with _root_.nestedProtocolFormats => }
-        |object Codec extends Codec with _root_.nestedProtocolExampleFormats with sjsonnew.BasicJsonProtocol with _root_.nestedProtocolFormats""".stripMargin.unindent)
+        |}""".stripMargin.unindent)
   }
 
   def protocolGenerateAbstractMethods = {
-    val gen = new CodecCodeGen(genFileName, codecName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
+    val gen = new CodecCodeGen(genFileName, protocolName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
     val schema = Schema parse generateArgDocExample
     val code = gen generate schema
 
@@ -154,13 +146,11 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
         |      serializationError("No known implementation of generateArgDocExample.")
         |    }
         |  }
-        |}
-        |trait Codec { self: _root_.generateArgDocExampleFormats with sjsonnew.BasicJsonProtocol => }
-        |object Codec extends Codec with _root_.generateArgDocExampleFormats with sjsonnew.BasicJsonProtocol""".stripMargin.unindent)
+        |}""".stripMargin.unindent)
   }
 
   override def recordGenerateSimple = {
-    val gen = new CodecCodeGen(genFileName, codecName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
+    val gen = new CodecCodeGen(genFileName, protocolName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
     val record = Record parse simpleRecordExample
     val code = gen generate record
 
@@ -185,13 +175,11 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
         |      builder.endObject()
         |    }
         |  }
-        |}
-        |trait Codec { self: _root_.simpleRecordExampleFormats with sjsonnew.BasicJsonProtocol => }
-        |object Codec extends Codec with _root_.simpleRecordExampleFormats with sjsonnew.BasicJsonProtocol""".stripMargin.unindent)
+        |}""".stripMargin.unindent)
   }
 
   override def recordGrowZeroToOneField = {
-    val gen = new CodecCodeGen(genFileName, codecName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
+    val gen = new CodecCodeGen(genFileName, protocolName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
     val record = Record parse growableAddOneFieldExample
     val code = gen generate record
 
@@ -216,13 +204,11 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
         |      builder.endObject()
         |    }
         |  }
-        |}
-        |trait Codec { self: _root_.growableAddOneFieldFormats with sjsonnew.BasicJsonProtocol => }
-        |object Codec extends Codec with _root_.growableAddOneFieldFormats with sjsonnew.BasicJsonProtocol""".stripMargin.unindent)
+        |}""".stripMargin.unindent)
   }
 
   override def schemaGenerateTypeReferences = {
-    val gen = new CodecCodeGen(genFileName, codecName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
+    val gen = new CodecCodeGen(genFileName, protocolName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
     val schema = Schema parse primitiveTypesExample
     val code = gen generate schema
 
@@ -254,13 +240,11 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
         |      builder.endObject()
         |    }
         |  }
-        |}
-        |trait Codec { self: _root_.primitiveTypesExampleFormats with sjsonnew.BasicJsonProtocol => }
-        |object Codec extends Codec with _root_.primitiveTypesExampleFormats with sjsonnew.BasicJsonProtocol""".stripMargin.unindent)
+        |}""".stripMargin.unindent)
   }
 
   override def schemaGenerateTypeReferencesNoLazy = {
-    val gen = new CodecCodeGen(genFileName, codecName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
+    val gen = new CodecCodeGen(genFileName, protocolName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
     val schema = Schema parse primitiveTypesNoLazyExample
     val code = gen generate schema
 
@@ -287,13 +271,12 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
         |      builder.endObject()
         |    }
         |  }
-        |}
-        |trait Codec { self: _root_.primitiveTypesNoLazyExampleFormats with sjsonnew.BasicJsonProtocol => }
-        |object Codec extends Codec with _root_.primitiveTypesNoLazyExampleFormats with sjsonnew.BasicJsonProtocol""".stripMargin.unindent)
+        |}""".stripMargin.unindent)
   }
 
   override def schemaGenerateComplete = {
-    val gen = new CodecCodeGen(genFileName, codecName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
+    val protocolName = Some("CustomProtcol")
+    val gen = new CodecCodeGen(genFileName, protocolName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
     val schema = Schema parse completeExample
     val code = gen generate schema
 
@@ -301,7 +284,8 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
   }
 
   override def schemaGenerateCompletePlusIndent = {
-    val gen = new CodecCodeGen(genFileName, codecName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
+    val protocolName = Some("CustomProtcol")
+    val gen = new CodecCodeGen(genFileName, protocolName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
     val schema = Schema parse completeExample
     val code = gen generate schema
 
@@ -309,7 +293,7 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
   }
 
   def fullCodecCheck = {
-    val gen = new CodecCodeGen(genFileName, codecName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
+    val gen = new CodecCodeGen(genFileName, protocolName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
     val schema = Schema parse s"""{
                                  |  "types": [
                                  |    {
@@ -332,9 +316,7 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
         |      serializationError("No known implementation of Greeting.")
         |    }
         |  }
-        |}
-        |trait Codec { self: _root_.GreetingFormats with sjsonnew.BasicJsonProtocol => }
-        |object Codec extends Codec with _root_.GreetingFormats with sjsonnew.BasicJsonProtocol""".stripMargin.unindent)
+        |}""".stripMargin.unindent)
   }
 
 }

--- a/library/src/test/scala/SchemaExample.scala
+++ b/library/src/test/scala/SchemaExample.scala
@@ -687,7 +687,7 @@ object NewSchema {
   val completeExampleCodeCodec =
     """package com.example
       |import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
-      |trait GreetingsFormats { self: sjsonnew.BasicJsonProtocol with com.example.GreetingHeaderFormats with java.io.FileFormats with com.example.SimpleGreetingFormats with com.example.GreetingWithAttachmentsFormats =>
+      |trait GreetingsFormats { self: com.example.GreetingHeaderFormats with com.example.GreetingWithAttachmentsFormats with java.io.FileFormats with com.example.SimpleGreetingFormats with sjsonnew.BasicJsonProtocol =>
       |implicit lazy val GreetingsFormat: JsonFormat[Greetings] = unionFormat2[Greetings, com.example.SimpleGreeting, com.example.GreetingWithAttachments]
       |}
       |import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
@@ -788,8 +788,8 @@ object NewSchema {
       |  }
       |}
       |}
-      |trait CustomProtcol { self: com.example.GreetingsFormats with sjsonnew.BasicJsonProtocol with com.example.GreetingHeaderFormats with com.example.PriorityLevelFormats with java.io.FileFormats with com.example.SimpleGreetingFormats with com.example.GreetingWithAttachmentsFormats with java.util.DateFormats => }
-      |object CustomProtcol extends CustomProtcol with com.example.GreetingsFormats with sjsonnew.BasicJsonProtocol with com.example.GreetingHeaderFormats with com.example.PriorityLevelFormats with java.io.FileFormats with com.example.SimpleGreetingFormats with com.example.GreetingWithAttachmentsFormats with java.util.DateFormats""".stripMargin
+      |trait CustomProtcol { self: com.example.GreetingsFormats with com.example.GreetingHeaderFormats with com.example.PriorityLevelFormats with java.util.DateFormats with com.example.GreetingWithAttachmentsFormats with java.io.FileFormats with com.example.SimpleGreetingFormats with sjsonnew.BasicJsonProtocol => }
+      |object CustomProtcol extends CustomProtcol with com.example.GreetingsFormats with com.example.GreetingHeaderFormats with com.example.PriorityLevelFormats with java.util.DateFormats with com.example.GreetingWithAttachmentsFormats with java.io.FileFormats with com.example.SimpleGreetingFormats with sjsonnew.BasicJsonProtocol""".stripMargin
 
 
   val growableAddOneFieldExample = """{

--- a/library/src/test/scala/SchemaExample.scala
+++ b/library/src/test/scala/SchemaExample.scala
@@ -788,8 +788,8 @@ object NewSchema {
       |  }
       |}
       |}
-      |trait Codec { self: com.example.GreetingsFormats with sjsonnew.BasicJsonProtocol with com.example.GreetingHeaderFormats with com.example.PriorityLevelFormats with java.io.FileFormats with com.example.SimpleGreetingFormats with com.example.GreetingWithAttachmentsFormats with java.util.DateFormats => }
-      |object Codec extends Codec with com.example.GreetingsFormats with sjsonnew.BasicJsonProtocol with com.example.GreetingHeaderFormats with com.example.PriorityLevelFormats with java.io.FileFormats with com.example.SimpleGreetingFormats with com.example.GreetingWithAttachmentsFormats with java.util.DateFormats""".stripMargin
+      |trait CustomProtcol { self: com.example.GreetingsFormats with sjsonnew.BasicJsonProtocol with com.example.GreetingHeaderFormats with com.example.PriorityLevelFormats with java.io.FileFormats with com.example.SimpleGreetingFormats with com.example.GreetingWithAttachmentsFormats with java.util.DateFormats => }
+      |object CustomProtcol extends CustomProtcol with com.example.GreetingsFormats with sjsonnew.BasicJsonProtocol with com.example.GreetingHeaderFormats with com.example.PriorityLevelFormats with java.io.FileFormats with com.example.SimpleGreetingFormats with com.example.GreetingWithAttachmentsFormats with java.util.DateFormats""".stripMargin
 
 
   val growableAddOneFieldExample = """{

--- a/library/src/test/scala/SchemaExample.scala
+++ b/library/src/test/scala/SchemaExample.scala
@@ -788,8 +788,8 @@ object NewSchema {
       |  }
       |}
       |}
-      |trait CustomProtcol { self: com.example.GreetingsFormats with com.example.GreetingHeaderFormats with com.example.PriorityLevelFormats with java.util.DateFormats with com.example.GreetingWithAttachmentsFormats with java.io.FileFormats with com.example.SimpleGreetingFormats with sjsonnew.BasicJsonProtocol => }
-      |object CustomProtcol extends CustomProtcol with com.example.GreetingsFormats with com.example.GreetingHeaderFormats with com.example.PriorityLevelFormats with java.util.DateFormats with com.example.GreetingWithAttachmentsFormats with java.io.FileFormats with com.example.SimpleGreetingFormats with sjsonnew.BasicJsonProtocol""".stripMargin
+      |trait CustomProtcol extends com.example.GreetingsFormats with com.example.GreetingHeaderFormats with com.example.PriorityLevelFormats with java.util.DateFormats with com.example.GreetingWithAttachmentsFormats with java.io.FileFormats with com.example.SimpleGreetingFormats with sjsonnew.BasicJsonProtocol
+      |object CustomProtcol extends CustomProtcol""".stripMargin
 
 
   val growableAddOneFieldExample = """{

--- a/plugin/src/sbt-test/sbt-datatype/roundtrip-test/build.sbt
+++ b/plugin/src/sbt-test/sbt-datatype/roundtrip-test/build.sbt
@@ -15,3 +15,5 @@ datatypeFormatsForType in generateDatatypes in Compile := { tpe =>
 libraryDependencies += "com.eed3si9n" %% "sjson-new-scalajson" % "0.4.0"
 
 enablePlugins(DatatypePlugin)
+
+scalacOptions += "-Xlog-implicits"

--- a/plugin/src/sbt-test/sbt-datatype/roundtrip-test/src/main/scala/com/example/Example.scala
+++ b/plugin/src/sbt-test/sbt-datatype/roundtrip-test/src/main/scala/com/example/Example.scala
@@ -2,17 +2,17 @@ package com.example
 
 import sjsonnew.JsonFormat
 import sjsonnew.support.scalajson.unsafe.Converter
-
+import interfaces.Greeting
 
 object Example extends App {
-  import Codec.GreetingFormat
-  val g0: interfaces.Greeting = new SimpleGreeting("Hello")
-  val g1: interfaces.Greeting = new SimpleGreeting("Hello", 0)
-  val g21: interfaces.Greeting = new GreetingWithAttachments(Array.empty, "Hello")
+  import CustomProtocol._
+  val g0: Greeting = new SimpleGreeting("Hello")
+  val g1: Greeting = new SimpleGreeting("Hello", 0)
+  val g21: Greeting = new GreetingWithAttachments(Array.empty, "Hello")
 
   println(Converter.toJson(g0).get)
 
-  assert(Converter.fromJson(Converter.toJson(g0).get).get == g0)
-  assert(Converter.fromJson(Converter.toJson(g1).get).get == g1)
-  assert(Converter.fromJson(Converter.toJson(g21).get).get == g21)
+  assert(Converter.fromJson[Greeting](Converter.toJson(g0).get).get == g0)
+  assert(Converter.fromJson[Greeting](Converter.toJson(g1).get).get == g1)
+  assert(Converter.fromJson[Greeting](Converter.toJson(g21).get).get == g21)
 }


### PR DESCRIPTION
1. Formats traits are capitalized.
2. What was called "full codec" (all formats traits) is now called a "protocol", and defaults to the name `CustomProtocol`. The build user can opt out of generating this by setting `None` to `datatypeProtocolName` setting. This usage of the term is consistent with sjson-new/sbinary.
3. `CustomProtocol` trait will inherit the formats traits instead of just listing them as self type.
4. The formats traits are topologically sorted so the most depended traits (such as `sjsonnew.BasicJsonProtocol`) would come last.
