### PR TITLE
move some of the codec settings into schema file

### DIFF
--- a/library/src/main/scala/CodeGen.scala
+++ b/library/src/main/scala/CodeGen.scala
@@ -1,14 +1,15 @@
 package sbt.datatype
 import scala.compat.Platform.EOL
 import java.io.File
+import scala.collection.immutable.ListMap
 
 /**
  * The base for code generators.
  */
 abstract class CodeGenerator {
 
-  implicit class MergeableMap[T](m: Map[T, String]) {
-    def merge(o: Map[T, String]): Map[T, String] =
+  implicit class ListMapOp[T](m: ListMap[T, String]) {
+    def merge(o: ListMap[T, String]): ListMap[T, String] =
       (o foldLeft m) { case (acc, (k, v)) =>
         val existing = acc get k getOrElse ""
 
@@ -22,6 +23,11 @@ abstract class CodeGenerator {
             acc + (k -> (existing + EOL + EOL + content))
         }
       }
+
+    def mapV(f: String => String): ListMap[T, String] =
+      ListMap(m.toList map { case (k, v) =>
+        (k, f(v))
+      }: _*)
   }
 
   implicit protected class IndentationAwareString(code: String) {
@@ -45,10 +51,10 @@ abstract class CodeGenerator {
   }
 
   /** Generate the code corresponding to all definitions in `s`. */
-  def generate(s: Schema): Map[File, String]
+  def generate(s: Schema): ListMap[File, String]
 
   /** Generate the code corresponding to `d`. */
-  protected final def generate(s: Schema, d: Definition, parent: Option[Interface], superFields: List[Field]): Map[File, String] =
+  protected final def generate(s: Schema, d: Definition, parent: Option[Interface], superFields: List[Field]): ListMap[File, String] =
     d match {
       case i: Interface   => generate(s, i, parent, superFields)
       case r: Record      => generate(s, r, parent, superFields)
@@ -56,13 +62,13 @@ abstract class CodeGenerator {
     }
 
   /** Generate the code corresponding to the interface `i`. */
-  protected def generate(s: Schema, i: Interface, parent: Option[Interface], superFields: List[Field]): Map[File, String]
+  protected def generate(s: Schema, i: Interface, parent: Option[Interface], superFields: List[Field]): ListMap[File, String]
 
   /** Generate the code corresponding to the record `r`. */
-  protected def generate(s: Schema, r: Record, parent: Option[Interface], superFields: List[Field]): Map[File, String]
+  protected def generate(s: Schema, r: Record, parent: Option[Interface], superFields: List[Field]): ListMap[File, String]
 
   /** Generate the code corresponding to the enumeration `e`. */
-  protected def generate(s: Schema, e: Enumeration): Map[File, String]
+  protected def generate(s: Schema, e: Enumeration): ListMap[File, String]
 
 }
 

--- a/library/src/main/scala/CodecCodeGen.scala
+++ b/library/src/main/scala/CodecCodeGen.scala
@@ -1,24 +1,23 @@
 package sbt.datatype
 import scala.compat.Platform.EOL
 import java.io.File
+import scala.collection.immutable.ListMap
 
 /**
  * Code generator to produce a codec for a given type.
  *
- * @param genFile             A function that maps a `Definition` to the `File` in which we should write it.
  * @param protocolName        The name of the full codec object to generate.
- * @param codecNamespace      The package to which the full codec object should belong.
  * @param codecParents        The parents that appear in the self type of all codecs, and the full codec inherits from.
  * @param instantiateJavaLazy How to transform an expression to its lazy equivalent in Java.
  * @param formatsForType      Given a `TpeRef` t, returns the list of codecs needed to encode t.
+ * @param includedSchemas     List of schemas that could be refereced.
  */
-class CodecCodeGen(genFile: Definition => File,
-  protocolName: Option[String],
-  codecNamespace: Option[String],
+class CodecCodeGen(protocolName: Option[String],
   codecParents: List[String],
   instantiateJavaLazy: String => String,
-  formatsForType: TpeRef => List[String]) extends CodeGenerator {
-
+  formatsForType: TpeRef => List[String],
+  includedSchemas: List[Schema]) extends CodeGenerator {
+  import CodecCodeGen._
   implicit object indentationConfiguration extends IndentationConfiguration {
     override val indentElement = "  "
     override def augmentIndentAfterTrigger(s: String) =
@@ -30,17 +29,18 @@ class CodecCodeGen(genFile: Definition => File,
     override def exitMultilineJavadoc(s: String) = s == "*/"
   }
 
-  override def generate(s: Schema, e: Enumeration): Map[File, String] = {
-    val readerValues = e.values map { case EnumerationValue(v, _) => s"""case "$v" => ${e.name}.$v""" }
-    val writerValues = e.values map { case EnumerationValue(v, _) => s"""case ${e.name}.$v => "$v"""" }
+  override def generate(s: Schema, e: Enumeration): ListMap[File, String] = {
+    val fqn = fullyQualifiedName(e)
+    val readerValues = e.values map { case EnumerationValue(v, _) => s"""case "$v" => $fqn.$v""" }
+    val writerValues = e.values map { case EnumerationValue(v, _) => s"""case $fqn.$v => "$v"""" }
     val selfType = makeSelfType(s, e, Nil)
 
     val code =
-      s"""${genPackage(e)}
+      s"""${genPackage(s)}
          |$sjsonImports
          |trait ${e.name.capitalize}Formats { $selfType
-         |  implicit lazy val ${e.name}Format: JsonFormat[${e.name}] = new JsonFormat[${e.name}] {
-         |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): ${e.name} = {
+         |  implicit lazy val ${e.name}Format: JsonFormat[$fqn] = new JsonFormat[$fqn] {
+         |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): $fqn = {
          |      jsOpt match {
          |        case Some(js) =>
          |          unbuilder.readString(js) match {
@@ -51,7 +51,7 @@ class CodecCodeGen(genFile: Definition => File,
          |      }
          |    }
          |
-         |    override def write[J](obj: ${e.name}, builder: Builder[J]): Unit = {
+         |    override def write[J](obj: $fqn, builder: Builder[J]): Unit = {
          |      val str = obj match {
          |        ${writerValues mkString EOL}
          |      }
@@ -60,26 +60,27 @@ class CodecCodeGen(genFile: Definition => File,
          |  }
          |}""".stripMargin
 
-    Map(genFile(e) -> code)
+    ListMap(genFile(s, e) -> code)
   }
 
-  override def generate(s: Schema, r: Record, parent: Option[Interface], superFields: List[Field]): Map[File, String] = {
+  override def generate(s: Schema, r: Record, parent: Option[Interface], superFields: List[Field]): ListMap[File, String] = {
     def accessField(f: Field) = {
       if (f.tpe.lzy && r.targetLang == "Java") scalaifyType(instantiateJavaLazy(f.name))
       else f.name
     }
+    val fqn = fullyQualifiedName(r)
     val allFields = r.fields ++ superFields
     val getFields = allFields map (f => s"""val ${f.name} = unbuilder.readField[${genRealTpe(f.tpe)}]("${f.name}")""") mkString EOL
-    val reconstruct = s"new ${r.name}(" + allFields.map(accessField).mkString(", ") + ")"
+    val reconstruct = s"new $fqn(" + allFields.map(accessField).mkString(", ") + ")"
     val writeFields = allFields map (f => s"""builder.addField("${f.name}", obj.${f.name})""") mkString EOL
     val selfType = makeSelfType(s, r, superFields)
 
     val code =
-      s"""${genPackage(r)}
+      s"""${genPackage(s)}
          |$sjsonImports
          |trait ${r.name.capitalize}Formats { $selfType
-         |  implicit lazy val ${r.name}Format: JsonFormat[${r.name}] = new JsonFormat[${r.name}] {
-         |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): ${r.name} = {
+         |  implicit lazy val ${r.name}Format: JsonFormat[$fqn] = new JsonFormat[$fqn] {
+         |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): $fqn = {
          |      jsOpt match {
          |        case Some(js) =>
          |          unbuilder.beginObject(js)
@@ -91,7 +92,7 @@ class CodecCodeGen(genFile: Definition => File,
          |      }
          |    }
          |
-         |    override def write[J](obj: ${r.name}, builder: Builder[J]): Unit = {
+         |    override def write[J](obj: $fqn, builder: Builder[J]): Unit = {
          |      builder.beginObject()
          |      $writeFields
          |      builder.endObject()
@@ -99,47 +100,49 @@ class CodecCodeGen(genFile: Definition => File,
          |  }
          |} """.stripMargin
 
-    Map(genFile(r) -> code)
+    ListMap(genFile(s, r) -> code)
   }
 
-  override def generate(s: Schema, i: Interface, parent: Option[Interface], superFields: List[Field]): Map[File, String] = {
+  override def generate(s: Schema, i: Interface, parent: Option[Interface], superFields: List[Field]): ListMap[File, String] = {
     val name = i.name
+    val fqn = fullyQualifiedName(i)
     val code =
       i.children match {
         case Nil =>
-          s"""${genPackage(i)}
+          s"""${genPackage(s)}
              |$sjsonImports
              |trait ${name.capitalize}Formats {
-             |  implicit lazy val ${name}Format: JsonFormat[${name}] = new JsonFormat[${name}] {
-             |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): ${i.name} = {
+             |  implicit lazy val ${name}Format: JsonFormat[$fqn] = new JsonFormat[$fqn] {
+             |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): $fqn = {
              |      deserializationError("No known implementation of ${i.name}.")
              |    }
-             |    override def write[J](obj: ${name}, builder: Builder[J]): Unit = {
+             |    override def write[J](obj: $fqn, builder: Builder[J]): Unit = {
              |      serializationError("No known implementation of ${name}.")
              |    }
              |  }
              |}""".stripMargin
 
         case xs =>
-          val unionFormat = s"unionFormat${xs.length}[${name}, ${xs map (c => c.namespace.getOrElse("_root_") + "." + c.name) mkString ", "}]"
+          val unionFormat = s"unionFormat${xs.length}[$fqn, ${xs map (c => c.namespace.getOrElse("_root_") + "." + c.name) mkString ", "}]"
 
           val selfType = getAllRequiredFormats(s, i, superFields).distinct match {
             case Nil => ""
             case fms => fms.mkString("self: ", " with ", " =>")
           }
-          s"""${genPackage(i)}
+          s"""${genPackage(s)}
              |$sjsonImports
              |trait ${name.capitalize}Formats { $selfType
-             |  implicit lazy val ${name}Format: JsonFormat[${name}] = $unionFormat
+             |  implicit lazy val ${name}Format: JsonFormat[$fqn] = $unionFormat
              |}""".stripMargin
 
       }
 
-    Map(genFile(i) -> code) :: (i.children map (generate(s, _, Some(i), i.fields ++ superFields))) reduce (_ merge _)
+    ListMap(genFile(s, i) -> code) :: (i.children map (generate(s, _, Some(i), i.fields ++ superFields))) reduce (_ merge _)
   }
 
-  override def generate(s: Schema): Map[File, String] = {
-    val codecs = s.definitions map (generate (s, _, None, Nil)) reduce (_ merge _) mapValues (_.indented)
+  override def generate(s: Schema): ListMap[File, String] = {
+    val codecs: ListMap[File, String] = ((s.definitions.toList map { d =>
+      ListMap(generate(s, d, None, Nil).toSeq: _*) }) reduce (_ merge _)) mapV (_.indented)
     protocolName match {
       case Some(x) =>
         val fullProtocol = generateFullProtocol(s, x)
@@ -148,6 +151,15 @@ class CodecCodeGen(genFile: Definition => File,
         codecs
     }
   }
+
+  private def genFile(s: Schema, d: Definition): File =
+    s.codecNamespace match {
+      case Some(ns) =>
+        val dir = new File(ns.replace(".", "/"))
+        new File(dir, s"${d.name}Formats.scala")
+      case _ =>
+        new File(s"${d.name}Formats.scala")
+    }
 
   /**
    * Returns the list of fully qualified codec names that we (non-transitively) need to generate a codec for `d`,
@@ -158,11 +170,11 @@ class CodecCodeGen(genFile: Definition => File,
       d match {
         case Interface(name, _, namespace, _, _, fields, _, _) =>
           val allFields = fields ++ superFields
-          allFields flatMap (f => formatsForType(f.tpe))
+          allFields flatMap (f => lookupFormats(f.tpe))
 
         case Record(_, _, _, _, _, fields) =>
           val allFields = fields ++ superFields
-          allFields flatMap (f => formatsForType(f.tpe))
+          allFields flatMap (f => lookupFormats(f.tpe))
 
         case _: Enumeration =>
           "sjsonnew.BasicJsonProtocol" :: Nil
@@ -173,8 +185,8 @@ class CodecCodeGen(genFile: Definition => File,
     typeFormats ++ unionFormat ++ codecParents
   }
 
-  private def fullFormatsName(d: Definition): String =
-    s"""${d.namespace getOrElse "_root_"}.${d.name.capitalize}Formats"""
+  private def fullyQualifiedName(d: Definition): String =
+    s"""${d.namespace getOrElse "_root_"}.${d.name}"""
 
   private def getAllRequiredFormats(s: Schema): List[String] = getAllRequiredFormats(s, s.definitions, Nil)
 
@@ -185,7 +197,7 @@ class CodecCodeGen(genFile: Definition => File,
    * The results are sorted topologically.
    */
   private def getAllRequiredFormats(s: Schema, ds: List[Definition], superFields: List[Field]): List[String] = {
-    val seedFormats = ds map { fullFormatsName }
+    val seedFormats = ds map { d => fullFormatsName(s, d) }
     def getAllDefinitions(d: Definition): List[Definition] =
       d match {
         case i: Interface => i :: (i.children flatMap {getAllDefinitions})
@@ -194,9 +206,9 @@ class CodecCodeGen(genFile: Definition => File,
     val allDefinitions = ds flatMap getAllDefinitions
     val dependencies: Map[String, List[String]] = Map(allDefinitions map { d =>
       val tpe = TpeRef((d.namespace.map(_ + ".").getOrElse("")) + d.name, false, false)
-      fullFormatsName(d) -> (d match {
+      fullFormatsName(s, d) -> (d match {
         case i: Interface =>
-          i.children.map(fullFormatsName) :::
+          i.children.map( c => fullFormatsName(s, c)) :::
           "sjsonnew.BasicJsonProtocol" :: getRequiredFormats(s, d, superFields)
         case _            => "sjsonnew.BasicJsonProtocol" :: getRequiredFormats(s, d, superFields)
       })
@@ -213,7 +225,7 @@ class CodecCodeGen(genFile: Definition => File,
    */
   private def getAllRequiredFormats(s: Schema, d: Definition, superFields: List[Field]): List[String] = d match {
     case i: Interface =>
-      val fmt = fullFormatsName(d)
+      val fmt = fullFormatsName(s, d)
       getAllRequiredFormats(s, i :: Nil, superFields) filter { _ != fmt }
     case r: Record =>
       getRequiredFormats(s, r, superFields)
@@ -231,8 +243,8 @@ class CodecCodeGen(genFile: Definition => File,
       case fms => fms.mkString("self: ", " with ", " =>")
     }
 
-  private def genPackage(d: Definition): String =
-    d.namespace map (ns => s"package $ns") getOrElse ""
+  private def genPackage(s: Schema): String =
+    s.codecNamespace map (p => s"package $p") getOrElse ""
 
   private val sjsonImports: String = "import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }"
 
@@ -255,17 +267,15 @@ class CodecCodeGen(genFile: Definition => File,
     case other     => other
   }
 
-  private def generateFullProtocol(s: Schema, name: String): Map[File, String] = {
+  private def generateFullProtocol(s: Schema, name: String): ListMap[File, String] = {
     val allFormats = getAllRequiredFormats(s).distinct
     val parents = allFormats.mkString("extends ", " with ", "")
     val code =
-      s"""${codecNamespace map (p => s"package $p") getOrElse ""}
+      s"""${genPackage(s)}
          |trait $name $parents
          |object $name extends $name""".stripMargin
-
-    val syntheticDefinition = Interface(name, "Scala", codecNamespace, VersionNumber("0.0.0"), Nil, Nil, Nil, Nil)
-
-    Map(genFile(syntheticDefinition) -> code)
+    val syntheticDefinition = Interface(name, "Scala", None, VersionNumber("0.0.0"), Nil, Nil, Nil, Nil)
+    ListMap(new File(genFile(s, syntheticDefinition).getParentFile, s"$name.scala") -> code)
   }
 
   private def allChildrenOf(d: Definition): List[Definition] = d match {
@@ -288,10 +298,26 @@ class CodecCodeGen(genFile: Definition => File,
     case _: Enumeration => false
   }
 
+  private def lookupFormats(tpe: TpeRef): List[String] =
+    lookupDefinition(tpe.name) match {
+      case Some((s, d)) => fullFormatsName(s, d) :: Nil
+      case _            => formatsForType(tpe)
+    }
 
+  private def lookupDefinition(fullName: String): Option[(Schema, Definition)] =
+    {
+      val (ns, name) = splitName(fullName)
+      (for {
+        s <- includedSchemas
+        d <- s.definitions if d.name == name && d.namespace == ns
+      } yield (s, d)).headOption
+    }
 }
 
 object CodecCodeGen {
+  def fullFormatsName(s: Schema, d: Definition): String =
+    s"""${s.codecNamespace map (_ + ".") getOrElse ""}${d.name.capitalize}Formats"""
+
   /** Removes all type parameters from `tpe` */
   def removeTypeParameters(tpe: TpeRef): TpeRef = tpe.copy(name = removeTypeParameters(tpe.name))
 
@@ -305,18 +331,17 @@ object CodecCodeGen {
    * A non-primitive types `com.example.Tpe` (except java.io.File) is mapped to `com.example.TpeFormat`.
    */
   val formatsForType: TpeRef => List[String] =
-    extensibleFormatsForType {
-      removeTypeParameters(_) match {
-        case TpeRef(name, _, _) if name contains "." =>
-          val tokens: List[String] = name.split("""\.""").toList.reverse
-          val cap = tokens match {
-            case x :: xs => (x.capitalize :: xs).reverse.mkString(".")
-            case x => x.mkString(".")
-          }
-          val xs = s"${cap}Formats" :: Nil
-          xs
-        case TpeRef(name, _, _) => s"_root_.${name.capitalize}Formats" :: Nil
-      }
+    extensibleFormatsForType { ref =>
+      val tpe = removeTypeParameters(ref)
+      val (ns, name) = splitName(tpe.name)
+      s"${ ns getOrElse "_root_" }.${name.capitalize}Formats" :: Nil
+    }
+
+  private def splitName(fullName: String): (Option[String], String) =
+    fullName.split("""\.""").toList.reverse match {
+      case List()  => (None, "")
+      case List(x) => (None, x)
+      case x :: xs => (Some(xs.reverse.mkString(".")), x)
     }
 
   /**

--- a/library/src/main/scala/MixedCodeGen.scala
+++ b/library/src/main/scala/MixedCodeGen.scala
@@ -1,6 +1,7 @@
 package sbt.datatype
 
 import java.io.File
+import scala.collection.immutable.ListMap
 
 /**
  * Generator that produces both Scala and Java code.
@@ -9,33 +10,33 @@ class MixedCodeGen(javaLazy: String, genScalaFileName: Definition => File, scala
   val javaGen  = new JavaCodeGen(javaLazy)
   val scalaGen = new ScalaCodeGen(genScalaFileName, scalaSealprotocols)
 
-  def generate(s: Schema): Map[File, String] =
+  def generate(s: Schema): ListMap[File, String] =
     s.definitions map (generate (s, _, None, Nil)) reduce (_ merge _)
 
-  def generate(s: Schema, i: Interface, parent: Option[Interface], superFields: List[Field]): Map[File, String] = {
+  def generate(s: Schema, i: Interface, parent: Option[Interface], superFields: List[Field]): ListMap[File, String] = {
     // We generate the code that corresponds to this protocol, but without its children, because they
     // may target another language. In this case, we have to make sure that we won't generate them
     // in the wrong language.
     val childLessProtocol = i.copy(children = Nil)
     val parentResult = childLessProtocol.targetLang match {
-      case "Scala" => scalaGen.generate(s, childLessProtocol, parent, superFields) mapValues (_ indentWith scalaGen.indentationConfiguration)
-      case "Java"  => javaGen.generate(s, childLessProtocol, parent, superFields) mapValues (_ indentWith javaGen.indentationConfiguration)
+      case "Scala" => scalaGen.generate(s, childLessProtocol, parent, superFields) mapV (_ indentWith scalaGen.indentationConfiguration)
+      case "Java"  => javaGen.generate(s, childLessProtocol, parent, superFields) mapV (_ indentWith javaGen.indentationConfiguration)
     }
 
     (parentResult :: (i.children map (generate(s, _, Some(i), i.fields ++ superFields)))) reduce (_ merge _)
 
   }
 
-  def generate(s: Schema, r: Record, parent: Option[Interface], superFields: List[Field]): Map[File, String] = {
+  def generate(s: Schema, r: Record, parent: Option[Interface], superFields: List[Field]): ListMap[File, String] = {
     r.targetLang match {
-      case "Scala" => scalaGen.generate(s, r, parent, superFields) mapValues (_ indentWith scalaGen.indentationConfiguration)
-      case "Java"  => javaGen.generate(s, r, parent, superFields) mapValues (_ indentWith javaGen.indentationConfiguration)
+      case "Scala" => scalaGen.generate(s, r, parent, superFields) mapV (_ indentWith scalaGen.indentationConfiguration)
+      case "Java"  => javaGen.generate(s, r, parent, superFields) mapV (_ indentWith javaGen.indentationConfiguration)
     }
   }
 
-  def generate(s: Schema, e: Enumeration): Map[File, String] =
+  def generate(s: Schema, e: Enumeration): ListMap[File, String] =
     e.targetLang match {
-      case "Scala" => scalaGen.generate(s, e) mapValues (_ indentWith scalaGen.indentationConfiguration)
-      case "Java"  => javaGen.generate(s, e) mapValues (_ indentWith javaGen.indentationConfiguration)
+      case "Scala" => scalaGen.generate(s, e) mapV (_ indentWith scalaGen.indentationConfiguration)
+      case "Java"  => javaGen.generate(s, e) mapV (_ indentWith javaGen.indentationConfiguration)
     }
 }

--- a/library/src/main/scala/ScalaCodeGen.scala
+++ b/library/src/main/scala/ScalaCodeGen.scala
@@ -1,6 +1,7 @@
 package sbt.datatype
 import scala.compat.Platform.EOL
 import java.io.File
+import scala.collection.immutable.ListMap
 
 /**
  * Code generator for Scala.
@@ -19,10 +20,10 @@ class ScalaCodeGen(genFile: Definition => File, sealProtocols: Boolean) extends 
   }
 
 
-  override def generate(s: Schema): Map[File, String] =
-    s.definitions map (generate (s, _, None, Nil)) reduce (_ merge _) mapValues (_.indented)
+  override def generate(s: Schema): ListMap[File, String] =
+    s.definitions.toList map (generate (s, _, None, Nil)) reduce (_ merge _) mapV (_.indented)
 
-  override def generate(s: Schema, e: Enumeration): Map[File, String] = {
+  override def generate(s: Schema, e: Enumeration): ListMap[File, String] = {
     val values =
       e.values map { case (EnumerationValue(name, doc)) =>
         s"""${genDoc(doc)}
@@ -37,10 +38,10 @@ class ScalaCodeGen(genFile: Definition => File, sealProtocols: Boolean) extends 
          |  $values
          |}""".stripMargin
 
-    Map(genFile(e) -> code)
+    ListMap(genFile(e) -> code)
   }
 
-  override def generate(s: Schema, r: Record, parent: Option[Interface], superFields: List[Field]): Map[File, String] = {
+  override def generate(s: Schema, r: Record, parent: Option[Interface], superFields: List[Field]): ListMap[File, String] = {
     val allFields = r.fields ++ superFields
 
     val alternativeCtors =
@@ -93,10 +94,10 @@ class ScalaCodeGen(genFile: Definition => File, sealProtocols: Boolean) extends 
          |  $applyOverloads
          |}""".stripMargin
 
-    Map(genFile(r) -> code)
+    ListMap(genFile(r) -> code)
   }
 
-  override def generate(s: Schema, i: Interface, parent: Option[Interface], superFields: List[Field]): Map[File, String] = {
+  override def generate(s: Schema, i: Interface, parent: Option[Interface], superFields: List[Field]): ListMap[File, String] = {
     val allFields = i.fields ++ superFields
 
     val alternativeCtors =
@@ -132,7 +133,7 @@ class ScalaCodeGen(genFile: Definition => File, sealProtocols: Boolean) extends 
          |  ${genToString(i, superFields)}
          |}""".stripMargin
 
-    Map(genFile(i) -> code) :: (i.children map (generate(s, _, Some(i), i.fields ++ superFields))) reduce (_ merge _)
+    ListMap(genFile(i) -> code) :: (i.children map (generate(s, _, Some(i), i.fields ++ superFields))) reduce (_ merge _)
   }
 
   private def genDoc(doc: List[String]) = doc match {

--- a/library/src/main/scala/SchemaData.scala
+++ b/library/src/main/scala/SchemaData.scala
@@ -87,12 +87,18 @@ object Definition extends Parser[Definition] {
  * Represents a complete schema definition.
  * Syntax:
  *   Schema := { "types": [ Definition* ] }
+ *             (, "codecNamespace": string constant)?
+ *             (, "fullCodec": string constant)? }
  */
-case class Schema(definitions: List[Definition])
+case class Schema(definitions: List[Definition],
+  codecNamespace: Option[String],
+  fullCodec: Option[String])
 
 object Schema extends Parser[Schema] {
   override def parse(json: JValue): Schema =
-    Schema(json ->* "types" map Definition.parse)
+    Schema(json ->* "types" map Definition.parse,
+      json ->? "codecNamespace",
+      json ->? "fullCodec")
 }
 
 /**

--- a/library/src/test/scala/CodeGenSpec.scala
+++ b/library/src/test/scala/CodeGenSpec.scala
@@ -11,7 +11,7 @@ abstract class GCodeGenSpec(language: String) extends Specification {
   }
 
   implicit def definition2Schema(d: Definition): Schema =
-    Schema(List(d))
+    Schema(List(d), Some("generated"), None)
 
   def is = s2"""
     This is a specification for the generation of $language code.
@@ -20,9 +20,9 @@ abstract class GCodeGenSpec(language: String) extends Specification {
       generate a simple enumeration              $enumerationGenerateSimple
 
     generate(Interface) should
-      generate a simple protocol                 $protocolGenerateSimple
-      generate a simple protocol with one child  $protocolGenerateOneChild
-      generate nested protocols                  $protocolGenerateNested
+      generate a simple interface                $protocolGenerateSimple
+      generate a simple interface with one child $protocolGenerateOneChild
+      generate nested interfaces                 $protocolGenerateNested
       generate abstract methods                  $protocolGenerateAbstractMethods
 
     generate(Record) should

--- a/library/src/test/scala/CodecCodeGenSpec.scala
+++ b/library/src/test/scala/CodecCodeGenSpec.scala
@@ -16,40 +16,37 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
 
   override def is = super.is append codecCodeGenSpec
 
-
-  val outputFile = new File("output.scala")
   val protocolName = None
-  val codecNamespace = None
   val codecParents = Nil
-  val genFileName = (_: Definition) => outputFile
   val instantiateJavaLazy = (s: String) => s"mkLazy($s)"
   val formatsForType: TpeRef => List[String] = CodecCodeGen.formatsForType
 
   override def enumerationGenerateSimple = {
-    val gen = new CodecCodeGen(genFileName, protocolName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
+    val gen = new CodecCodeGen(protocolName, codecParents, instantiateJavaLazy, formatsForType, Nil)
     val enumeration = Enumeration parse simpleEnumerationExample
     val code = gen generate enumeration
 
     code.head._2.unindent must containTheSameElementsAs(
-      """import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
+      """package generated
+        |import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
         |trait SimpleEnumerationExampleFormats { self: sjsonnew.BasicJsonProtocol =>
-        |  implicit lazy val simpleEnumerationExampleFormat: JsonFormat[simpleEnumerationExample] = new JsonFormat[simpleEnumerationExample] {
-        |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): simpleEnumerationExample = {
+        |  implicit lazy val simpleEnumerationExampleFormat: JsonFormat[_root_.simpleEnumerationExample] = new JsonFormat[_root_.simpleEnumerationExample] {
+        |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): _root_.simpleEnumerationExample = {
         |      jsOpt match {
         |        case Some(js) =>
         |          unbuilder.readString(js) match {
-        |            case "first" => simpleEnumerationExample.first
-        |            case "second" => simpleEnumerationExample.second
+        |            case "first" => _root_.simpleEnumerationExample.first
+        |            case "second" => _root_.simpleEnumerationExample.second
         |          }
         |        case None =>
         |          deserializationError("Expected JsString but found None")
         |      }
         |    }
         |
-        |    override def write[J](obj: simpleEnumerationExample, builder: Builder[J]): Unit = {
+        |    override def write[J](obj: _root_.simpleEnumerationExample, builder: Builder[J]): Unit = {
         |      val str = obj match {
-        |        case simpleEnumerationExample.first => "first"
-        |        case simpleEnumerationExample.second => "second"
+        |        case _root_.simpleEnumerationExample.first => "first"
+        |        case _root_.simpleEnumerationExample.second => "second"
         |      }
         |      builder.writeString(str)
         |    }
@@ -58,18 +55,19 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
   }
 
   override def protocolGenerateSimple = {
-    val gen = new CodecCodeGen(genFileName, protocolName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
-    val protocol = Interface parse simpleProtocolExample
-    val code = gen generate protocol
+    val gen = new CodecCodeGen(protocolName, codecParents, instantiateJavaLazy, formatsForType, Nil)
+    val intf = Interface parse simpleProtocolExample
+    val code = gen generate intf
 
     code.head._2.unindent must containTheSameElementsAs(
-      """import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
+      """package generated
+        |import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
         |trait SimpleProtocolExampleFormats {
-        |  implicit lazy val simpleProtocolExampleFormat: JsonFormat[simpleProtocolExample] = new JsonFormat[simpleProtocolExample] {
-        |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): simpleProtocolExample = {
+        |  implicit lazy val simpleProtocolExampleFormat: JsonFormat[_root_.simpleProtocolExample] = new JsonFormat[_root_.simpleProtocolExample] {
+        |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): _root_.simpleProtocolExample = {
         |      deserializationError("No known implementation of simpleProtocolExample.")
         |    }
-        |    override def write[J](obj: simpleProtocolExample, builder: Builder[J]): Unit = {
+        |    override def write[J](obj: _root_.simpleProtocolExample, builder: Builder[J]): Unit = {
         |      serializationError("No known implementation of simpleProtocolExample.")
         |    }
         |  }
@@ -77,72 +75,79 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
   }
 
   override def protocolGenerateOneChild = {
-    val gen = new CodecCodeGen(genFileName, protocolName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
-    val protocol = Interface parse oneChildProtocolExample
-    val code = gen generate protocol
+    val gen = new CodecCodeGen(protocolName, codecParents, instantiateJavaLazy, formatsForType, Nil)
+    val intf = Interface parse oneChildProtocolExample
+    val code = gen generate intf
 
-    code.head._2.unindent must containTheSameElementsAs(
-      """import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
-        |trait OneChildProtocolExampleFormats { self: _root_.ChildRecordFormats with sjsonnew.BasicJsonProtocol =>
-        |  implicit lazy val oneChildProtocolExampleFormat: JsonFormat[oneChildProtocolExample] = unionFormat1[oneChildProtocolExample, _root_.childRecord]
-        |}
+    (code(new File("generated", "oneChildProtocolExampleFormats.scala")).unindent must containTheSameElementsAs(
+      """package generated
+        |import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
+        |trait OneChildProtocolExampleFormats { self: generated.ChildRecordFormats with sjsonnew.BasicJsonProtocol =>
+        |  implicit lazy val oneChildProtocolExampleFormat: JsonFormat[_root_.oneChildProtocolExample] = unionFormat1[_root_.oneChildProtocolExample, _root_.childRecord]
+        |}""".stripMargin.unindent)) and
+    (code(new File("generated", "childRecordFormats.scala")).unindent must containTheSameElementsAs(
+      """package generated
         |import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
         |trait ChildRecordFormats {
-        |  implicit lazy val childRecordFormat: JsonFormat[childRecord] = new JsonFormat[childRecord] {
-        |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): childRecord = {
+        |  implicit lazy val childRecordFormat: JsonFormat[_root_.childRecord] = new JsonFormat[_root_.childRecord] {
+        |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): _root_.childRecord = {
         |      jsOpt match {
         |        case Some(js) =>
         |          unbuilder.beginObject(js)
         |          unbuilder.endObject()
-        |          new childRecord()
+        |          new _root_.childRecord()
         |        case None =>
         |          deserializationError("Expected JsObject but found None")
         |      }
         |    }
-        |    override def write[J](obj: childRecord, builder: Builder[J]): Unit = {
+        |    override def write[J](obj: _root_.childRecord, builder: Builder[J]): Unit = {
         |      builder.beginObject()
         |      builder.endObject()
         |    }
         |  }
-        |}""".stripMargin.unindent)
+        |}""".stripMargin.unindent))
   }
 
   override def protocolGenerateNested = {
-    val gen = new CodecCodeGen(genFileName, protocolName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
-    val protocol = Interface parse nestedProtocolExample
-    val code = gen generate protocol
+    val gen = new CodecCodeGen(protocolName, codecParents, instantiateJavaLazy, formatsForType, Nil)
+    val intf = Interface parse nestedProtocolExample
+    val code = gen generate intf
 
-    code.head._2.unindent must containTheSameElementsAs(
-      """import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
-        |trait NestedProtocolExampleFormats { self: _root_.NestedProtocolFormats with sjsonnew.BasicJsonProtocol =>
-        |  implicit lazy val nestedProtocolExampleFormat: JsonFormat[nestedProtocolExample] = unionFormat1[nestedProtocolExample, _root_.nestedProtocol]
-        |}
+    (code(new File("generated", "nestedProtocolExampleFormats.scala")).unindent must containTheSameElementsAs(
+      """package generated
+        |import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
+        |trait NestedProtocolExampleFormats { self: generated.NestedProtocolFormats with sjsonnew.BasicJsonProtocol =>
+        |  implicit lazy val nestedProtocolExampleFormat: JsonFormat[_root_.nestedProtocolExample] = unionFormat1[_root_.nestedProtocolExample, _root_.nestedProtocol]
+        |}""".stripMargin.unindent)) and
+    (code(new File("generated", "nestedProtocolFormats.scala")).unindent must containTheSameElementsAs(
+      """package generated
         |import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
         |trait NestedProtocolFormats {
-        |  implicit lazy val nestedProtocolFormat: JsonFormat[nestedProtocol] = new JsonFormat[nestedProtocol] {
-        |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): nestedProtocol = {
+        |  implicit lazy val nestedProtocolFormat: JsonFormat[_root_.nestedProtocol] = new JsonFormat[_root_.nestedProtocol] {
+        |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): _root_.nestedProtocol = {
         |      deserializationError("No known implementation of nestedProtocol.")
         |    }
-        |    override def write[J](obj: nestedProtocol, builder: Builder[J]): Unit = {
+        |    override def write[J](obj: _root_.nestedProtocol, builder: Builder[J]): Unit = {
         |      serializationError("No known implementation of nestedProtocol.")
         |    }
         |  }
-        |}""".stripMargin.unindent)
+        |}""".stripMargin.unindent))
   }
 
   def protocolGenerateAbstractMethods = {
-    val gen = new CodecCodeGen(genFileName, protocolName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
     val schema = Schema parse generateArgDocExample
+    val gen = new CodecCodeGen(protocolName, codecParents, instantiateJavaLazy, formatsForType, schema :: Nil)
     val code = gen generate schema
 
     code.head._2.unindent must containTheSameElementsAs(
-      """import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
+      """package generated
+        |import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
         |trait GenerateArgDocExampleFormats {
-        |  implicit lazy val generateArgDocExampleFormat: JsonFormat[generateArgDocExample] = new JsonFormat[generateArgDocExample] {
-        |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): generateArgDocExample = {
+        |  implicit lazy val generateArgDocExampleFormat: JsonFormat[_root_.generateArgDocExample] = new JsonFormat[_root_.generateArgDocExample] {
+        |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): _root_.generateArgDocExample = {
         |      deserializationError("No known implementation of generateArgDocExample.")
         |    }
-        |    override def write[J](obj: generateArgDocExample, builder: Builder[J]): Unit = {
+        |    override def write[J](obj: _root_.generateArgDocExample, builder: Builder[J]): Unit = {
         |      serializationError("No known implementation of generateArgDocExample.")
         |    }
         |  }
@@ -150,26 +155,27 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
   }
 
   override def recordGenerateSimple = {
-    val gen = new CodecCodeGen(genFileName, protocolName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
+    val gen = new CodecCodeGen(protocolName, codecParents, instantiateJavaLazy, formatsForType, Nil)
     val record = Record parse simpleRecordExample
     val code = gen generate record
 
     code.head._2.unindent must containTheSameElementsAs(
-      """import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
+      """package generated
+        |import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
         |trait SimpleRecordExampleFormats { self: sjsonnew.BasicJsonProtocol =>
-        |  implicit lazy val simpleRecordExampleFormat: JsonFormat[simpleRecordExample] = new JsonFormat[simpleRecordExample] {
-        |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): simpleRecordExample = {
+        |  implicit lazy val simpleRecordExampleFormat: JsonFormat[_root_.simpleRecordExample] = new JsonFormat[_root_.simpleRecordExample] {
+        |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): _root_.simpleRecordExample = {
         |      jsOpt match {
         |        case Some(js) =>
         |          unbuilder.beginObject(js)
         |          val field = unbuilder.readField[java.net.URL]("field")
         |          unbuilder.endObject()
-        |          new simpleRecordExample(field)
+        |          new _root_.simpleRecordExample(field)
         |        case None =>
         |          deserializationError("Expected JsObject but found None")
         |      }
         |    }
-        |    override def write[J](obj: simpleRecordExample, builder: Builder[J]): Unit = {
+        |    override def write[J](obj: _root_.simpleRecordExample, builder: Builder[J]): Unit = {
         |      builder.beginObject()
         |      builder.addField("field", obj.field)
         |      builder.endObject()
@@ -179,26 +185,27 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
   }
 
   override def recordGrowZeroToOneField = {
-    val gen = new CodecCodeGen(genFileName, protocolName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
+    val gen = new CodecCodeGen(protocolName, codecParents, instantiateJavaLazy, formatsForType, Nil)
     val record = Record parse growableAddOneFieldExample
     val code = gen generate record
 
     code.head._2.unindent must containTheSameElementsAs(
-      """import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
+      """package generated
+        |import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
         |trait GrowableAddOneFieldFormats { self: sjsonnew.BasicJsonProtocol =>
-        |  implicit lazy val growableAddOneFieldFormat: JsonFormat[growableAddOneField] = new JsonFormat[growableAddOneField] {
-        |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): growableAddOneField = {
+        |  implicit lazy val growableAddOneFieldFormat: JsonFormat[_root_.growableAddOneField] = new JsonFormat[_root_.growableAddOneField] {
+        |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): _root_.growableAddOneField = {
         |      jsOpt match {
         |        case Some(js) =>
         |          unbuilder.beginObject(js)
         |          val field = unbuilder.readField[Int]("field")
         |          unbuilder.endObject()
-        |          new growableAddOneField(field)
+        |          new _root_.growableAddOneField(field)
         |        case None =>
         |          deserializationError("Expected JsObject but found None")
         |      }
         |    }
-        |    override def write[J](obj: growableAddOneField, builder: Builder[J]): Unit = {
+        |    override def write[J](obj: _root_.growableAddOneField, builder: Builder[J]): Unit = {
         |      builder.beginObject()
         |      builder.addField("field", obj.field)
         |      builder.endObject()
@@ -208,15 +215,15 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
   }
 
   override def schemaGenerateTypeReferences = {
-    val gen = new CodecCodeGen(genFileName, protocolName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
     val schema = Schema parse primitiveTypesExample
+    val gen = new CodecCodeGen(protocolName, codecParents, instantiateJavaLazy, formatsForType, schema :: Nil)
     val code = gen generate schema
 
     code.head._2.unindent must containTheSameElementsAs(
       """import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
         |trait PrimitiveTypesExampleFormats { self: sjsonnew.BasicJsonProtocol =>
-        |  implicit lazy val primitiveTypesExampleFormat: JsonFormat[primitiveTypesExample] = new JsonFormat[primitiveTypesExample] {
-        |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): primitiveTypesExample = {
+        |  implicit lazy val primitiveTypesExampleFormat: JsonFormat[_root_.primitiveTypesExample] = new JsonFormat[_root_.primitiveTypesExample] {
+        |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): _root_.primitiveTypesExample = {
         |      jsOpt match {
         |        case Some(js) =>
         |          unbuilder.beginObject(js)
@@ -225,13 +232,13 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
         |          val arrayInteger = unbuilder.readField[Array[Int]]("arrayInteger")
         |          val lazyArrayInteger = unbuilder.readField[Array[Int]]("lazyArrayInteger")
         |          unbuilder.endObject()
-        |          new primitiveTypesExample(simpleInteger, lazyInteger, arrayInteger, lazyArrayInteger)
+        |          new _root_.primitiveTypesExample(simpleInteger, lazyInteger, arrayInteger, lazyArrayInteger)
         |        case None =>
         |          deserializationError("Expected JsObject but found None")
         |      }
         |    }
         |
-        |    override def write[J](obj: primitiveTypesExample, builder: Builder[J]): Unit = {
+        |    override def write[J](obj: _root_.primitiveTypesExample, builder: Builder[J]): Unit = {
         |      builder.beginObject()
         |      builder.addField("simpleInteger", obj.simpleInteger)
         |      builder.addField("lazyInteger", obj.lazyInteger)
@@ -244,27 +251,27 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
   }
 
   override def schemaGenerateTypeReferencesNoLazy = {
-    val gen = new CodecCodeGen(genFileName, protocolName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
     val schema = Schema parse primitiveTypesNoLazyExample
+    val gen = new CodecCodeGen(protocolName, codecParents, instantiateJavaLazy, formatsForType, schema :: Nil)
     val code = gen generate schema
 
     code.head._2.unindent must containTheSameElementsAs(
       """import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
         |trait PrimitiveTypesNoLazyExampleFormats { self: sjsonnew.BasicJsonProtocol =>
-        |  implicit lazy val primitiveTypesNoLazyExampleFormat: JsonFormat[primitiveTypesNoLazyExample] = new JsonFormat[primitiveTypesNoLazyExample] {
-        |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): primitiveTypesNoLazyExample = {
+        |  implicit lazy val primitiveTypesNoLazyExampleFormat: JsonFormat[_root_.primitiveTypesNoLazyExample] = new JsonFormat[_root_.primitiveTypesNoLazyExample] {
+        |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): _root_.primitiveTypesNoLazyExample = {
         |      jsOpt match {
         |        case Some(js) =>
         |          unbuilder.beginObject(js)
         |          val simpleInteger = unbuilder.readField[Int]("simpleInteger")
         |          val arrayInteger = unbuilder.readField[Array[Int]]("arrayInteger")
         |          unbuilder.endObject()
-        |          new primitiveTypesNoLazyExample(simpleInteger, arrayInteger)
+        |          new _root_.primitiveTypesNoLazyExample(simpleInteger, arrayInteger)
         |        case None =>
         |          deserializationError("Expected JsObject but found None")
         |      }
         |    }
-        |    override def write[J](obj: primitiveTypesNoLazyExample, builder: Builder[J]): Unit = {
+        |    override def write[J](obj: _root_.primitiveTypesNoLazyExample, builder: Builder[J]): Unit = {
         |      builder.beginObject()
         |      builder.addField("simpleInteger", obj.simpleInteger)
         |      builder.addField("arrayInteger", obj.arrayInteger)
@@ -276,24 +283,23 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
 
   override def schemaGenerateComplete = {
     val protocolName = Some("CustomProtcol")
-    val gen = new CodecCodeGen(genFileName, protocolName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
     val schema = Schema parse completeExample
+    val gen = new CodecCodeGen(protocolName, codecParents, instantiateJavaLazy, formatsForType, schema :: Nil)
     val code = gen generate schema
 
-    code.head._2.unindent must containTheSameElementsAs(completeExampleCodeCodec.unindent)
+    code.values.mkString.unindent must containTheSameElementsAs(completeExampleCodeCodec.unindent)
   }
 
   override def schemaGenerateCompletePlusIndent = {
     val protocolName = Some("CustomProtcol")
-    val gen = new CodecCodeGen(genFileName, protocolName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
     val schema = Schema parse completeExample
+    val gen = new CodecCodeGen(protocolName, codecParents, instantiateJavaLazy, formatsForType, schema :: Nil)
     val code = gen generate schema
 
-    code.head._2.withoutEmptyLines must containTheSameElementsAs(completeExampleCodeCodec.withoutEmptyLines)
+    code.values.mkString.withoutEmptyLines must containTheSameElementsAs(completeExampleCodeCodec.withoutEmptyLines)
   }
 
   def fullCodecCheck = {
-    val gen = new CodecCodeGen(genFileName, protocolName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
     val schema = Schema parse s"""{
                                  |  "types": [
                                  |    {
@@ -303,16 +309,17 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
                                  |    }
                                  |  ]
                                  |}""".stripMargin
+    val gen = new CodecCodeGen(protocolName, codecParents, instantiateJavaLazy, formatsForType, schema :: Nil)
     val code = gen generate schema
 
     code.head._2.unindent must containTheSameElementsAs(
       """import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
         |trait GreetingFormats {
-        |  implicit lazy val GreetingFormat: JsonFormat[Greeting] = new JsonFormat[Greeting] {
-        |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): Greeting = {
+        |  implicit lazy val GreetingFormat: JsonFormat[_root_.Greeting] = new JsonFormat[_root_.Greeting] {
+        |    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): _root_.Greeting = {
         |      deserializationError("No known implementation of Greeting.")
         |    }
-        |    override def write[J](obj: Greeting, builder: Builder[J]): Unit = {
+        |    override def write[J](obj: _root_.Greeting, builder: Builder[J]): Unit = {
         |      serializationError("No known implementation of Greeting.")
         |    }
         |  }

--- a/library/src/test/scala/CodecCodeGenSpec.scala
+++ b/library/src/test/scala/CodecCodeGenSpec.scala
@@ -16,13 +16,12 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
 
   override def is = super.is append codecCodeGenSpec
 
-  val protocolName = None
   val codecParents = Nil
   val instantiateJavaLazy = (s: String) => s"mkLazy($s)"
   val formatsForType: TpeRef => List[String] = CodecCodeGen.formatsForType
 
   override def enumerationGenerateSimple = {
-    val gen = new CodecCodeGen(protocolName, codecParents, instantiateJavaLazy, formatsForType, Nil)
+    val gen = new CodecCodeGen(codecParents, instantiateJavaLazy, formatsForType, Nil)
     val enumeration = Enumeration parse simpleEnumerationExample
     val code = gen generate enumeration
 
@@ -55,7 +54,7 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
   }
 
   override def protocolGenerateSimple = {
-    val gen = new CodecCodeGen(protocolName, codecParents, instantiateJavaLazy, formatsForType, Nil)
+    val gen = new CodecCodeGen(codecParents, instantiateJavaLazy, formatsForType, Nil)
     val intf = Interface parse simpleProtocolExample
     val code = gen generate intf
 
@@ -75,7 +74,7 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
   }
 
   override def protocolGenerateOneChild = {
-    val gen = new CodecCodeGen(protocolName, codecParents, instantiateJavaLazy, formatsForType, Nil)
+    val gen = new CodecCodeGen(codecParents, instantiateJavaLazy, formatsForType, Nil)
     val intf = Interface parse oneChildProtocolExample
     val code = gen generate intf
 
@@ -109,7 +108,7 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
   }
 
   override def protocolGenerateNested = {
-    val gen = new CodecCodeGen(protocolName, codecParents, instantiateJavaLazy, formatsForType, Nil)
+    val gen = new CodecCodeGen(codecParents, instantiateJavaLazy, formatsForType, Nil)
     val intf = Interface parse nestedProtocolExample
     val code = gen generate intf
 
@@ -136,7 +135,7 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
 
   def protocolGenerateAbstractMethods = {
     val schema = Schema parse generateArgDocExample
-    val gen = new CodecCodeGen(protocolName, codecParents, instantiateJavaLazy, formatsForType, schema :: Nil)
+    val gen = new CodecCodeGen(codecParents, instantiateJavaLazy, formatsForType, schema :: Nil)
     val code = gen generate schema
 
     code.head._2.unindent must containTheSameElementsAs(
@@ -155,7 +154,7 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
   }
 
   override def recordGenerateSimple = {
-    val gen = new CodecCodeGen(protocolName, codecParents, instantiateJavaLazy, formatsForType, Nil)
+    val gen = new CodecCodeGen(codecParents, instantiateJavaLazy, formatsForType, Nil)
     val record = Record parse simpleRecordExample
     val code = gen generate record
 
@@ -185,7 +184,7 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
   }
 
   override def recordGrowZeroToOneField = {
-    val gen = new CodecCodeGen(protocolName, codecParents, instantiateJavaLazy, formatsForType, Nil)
+    val gen = new CodecCodeGen(codecParents, instantiateJavaLazy, formatsForType, Nil)
     val record = Record parse growableAddOneFieldExample
     val code = gen generate record
 
@@ -216,7 +215,7 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
 
   override def schemaGenerateTypeReferences = {
     val schema = Schema parse primitiveTypesExample
-    val gen = new CodecCodeGen(protocolName, codecParents, instantiateJavaLazy, formatsForType, schema :: Nil)
+    val gen = new CodecCodeGen(codecParents, instantiateJavaLazy, formatsForType, schema :: Nil)
     val code = gen generate schema
 
     code.head._2.unindent must containTheSameElementsAs(
@@ -252,7 +251,7 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
 
   override def schemaGenerateTypeReferencesNoLazy = {
     val schema = Schema parse primitiveTypesNoLazyExample
-    val gen = new CodecCodeGen(protocolName, codecParents, instantiateJavaLazy, formatsForType, schema :: Nil)
+    val gen = new CodecCodeGen(codecParents, instantiateJavaLazy, formatsForType, schema :: Nil)
     val code = gen generate schema
 
     code.head._2.unindent must containTheSameElementsAs(
@@ -282,18 +281,16 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
   }
 
   override def schemaGenerateComplete = {
-    val protocolName = Some("CustomProtcol")
     val schema = Schema parse completeExample
-    val gen = new CodecCodeGen(protocolName, codecParents, instantiateJavaLazy, formatsForType, schema :: Nil)
+    val gen = new CodecCodeGen(codecParents, instantiateJavaLazy, formatsForType, schema :: Nil)
     val code = gen generate schema
 
     code.values.mkString.unindent must containTheSameElementsAs(completeExampleCodeCodec.unindent)
   }
 
   override def schemaGenerateCompletePlusIndent = {
-    val protocolName = Some("CustomProtcol")
     val schema = Schema parse completeExample
-    val gen = new CodecCodeGen(protocolName, codecParents, instantiateJavaLazy, formatsForType, schema :: Nil)
+    val gen = new CodecCodeGen(codecParents, instantiateJavaLazy, formatsForType, schema :: Nil)
     val code = gen generate schema
 
     code.values.mkString.withoutEmptyLines must containTheSameElementsAs(completeExampleCodeCodec.withoutEmptyLines)
@@ -309,7 +306,7 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
                                  |    }
                                  |  ]
                                  |}""".stripMargin
-    val gen = new CodecCodeGen(protocolName, codecParents, instantiateJavaLazy, formatsForType, schema :: Nil)
+    val gen = new CodecCodeGen(codecParents, instantiateJavaLazy, formatsForType, schema :: Nil)
     val code = gen generate schema
 
     code.head._2.unindent must containTheSameElementsAs(

--- a/library/src/test/scala/SchemaExample.scala
+++ b/library/src/test/scala/SchemaExample.scala
@@ -197,6 +197,7 @@ object NewSchema {
 }"""
 
   val generateArgDocExample = """{
+  "codecNamespace": "generated",
   "types": [
     {
       "name": "generateArgDocExample",
@@ -239,6 +240,8 @@ object NewSchema {
 }"""
 
   val completeExample = """{
+  "codecNamespace": "generated",
+  "fullCodec": "CustomProtcol",
   "types": [
     {
       "name": "Greetings",
@@ -685,27 +688,28 @@ object NewSchema {
           |}""".stripMargin)
 
   val completeExampleCodeCodec =
-    """package com.example
+    """package generated
       |import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
-      |trait GreetingsFormats { self: com.example.GreetingHeaderFormats with com.example.GreetingWithAttachmentsFormats with java.io.FileFormats with com.example.SimpleGreetingFormats with sjsonnew.BasicJsonProtocol =>
-      |implicit lazy val GreetingsFormat: JsonFormat[Greetings] = unionFormat2[Greetings, com.example.SimpleGreeting, com.example.GreetingWithAttachments]
+      |trait GreetingsFormats { self: generated.GreetingHeaderFormats with generated.GreetingWithAttachmentsFormats with java.io.FileFormats with generated.SimpleGreetingFormats with sjsonnew.BasicJsonProtocol =>
+      |implicit lazy val GreetingsFormat: JsonFormat[com.example.Greetings] = unionFormat2[com.example.Greetings, com.example.SimpleGreeting, com.example.GreetingWithAttachments]
       |}
+      |package generated
       |import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
-      |trait SimpleGreetingFormats { self: sjsonnew.BasicJsonProtocol with com.example.GreetingHeaderFormats =>
-      |implicit lazy val SimpleGreetingFormat: JsonFormat[SimpleGreeting] = new JsonFormat[SimpleGreeting] {
-      |  override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): SimpleGreeting = {
+      |trait SimpleGreetingFormats { self: sjsonnew.BasicJsonProtocol with generated.GreetingHeaderFormats =>
+      |implicit lazy val SimpleGreetingFormat: JsonFormat[com.example.SimpleGreeting] = new JsonFormat[com.example.SimpleGreeting] {
+      |  override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): com.example.SimpleGreeting = {
       |    jsOpt match {
       |      case Some(js) =>
       |      unbuilder.beginObject(js)
       |      val message = unbuilder.readField[String]("message")
       |      val header = unbuilder.readField[com.example.GreetingHeader]("header")
       |      unbuilder.endObject()
-      |      new SimpleGreeting(message, header)
+      |      new com.example.SimpleGreeting(message, header)
       |      case None =>
       |      deserializationError("Expected JsObject but found None")
       |    }
       |  }
-      |  override def write[J](obj: SimpleGreeting, builder: Builder[J]): Unit = {
+      |  override def write[J](obj: com.example.SimpleGreeting, builder: Builder[J]): Unit = {
       |    builder.beginObject()
       |    builder.addField("message", obj.message)
       |    builder.addField("header", obj.header)
@@ -713,10 +717,11 @@ object NewSchema {
       |  }
       |}
       |}
+      |package generated
       |import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
-      |trait GreetingWithAttachmentsFormats { self: java.io.FileFormats with sjsonnew.BasicJsonProtocol with com.example.GreetingHeaderFormats =>
-      |implicit lazy val GreetingWithAttachmentsFormat: JsonFormat[GreetingWithAttachments] = new JsonFormat[GreetingWithAttachments] {
-      |  override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): GreetingWithAttachments = {
+      |trait GreetingWithAttachmentsFormats { self: java.io.FileFormats with sjsonnew.BasicJsonProtocol with generated.GreetingHeaderFormats =>
+      |implicit lazy val GreetingWithAttachmentsFormat: JsonFormat[com.example.GreetingWithAttachments] = new JsonFormat[com.example.GreetingWithAttachments] {
+      |  override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): com.example.GreetingWithAttachments = {
       |    jsOpt match {
       |      case Some(js) =>
       |      unbuilder.beginObject(js)
@@ -724,12 +729,12 @@ object NewSchema {
       |      val message = unbuilder.readField[String]("message")
       |      val header = unbuilder.readField[com.example.GreetingHeader]("header")
       |      unbuilder.endObject()
-      |      new GreetingWithAttachments(attachments, message, header)
+      |      new com.example.GreetingWithAttachments(attachments, message, header)
       |      case None =>
       |      deserializationError("Expected JsObject but found None")
       |    }
       |  }
-      |  override def write[J](obj: GreetingWithAttachments, builder: Builder[J]): Unit = {
+      |  override def write[J](obj: com.example.GreetingWithAttachments, builder: Builder[J]): Unit = {
       |    builder.beginObject()
       |    builder.addField("attachments", obj.attachments)
       |    builder.addField("message", obj.message)
@@ -738,10 +743,11 @@ object NewSchema {
       |  }
       |}
       |}
+      |package generated
       |import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
-      |trait GreetingHeaderFormats { self: java.util.DateFormats with sjsonnew.BasicJsonProtocol with com.example.PriorityLevelFormats =>
-      |implicit lazy val GreetingHeaderFormat: JsonFormat[GreetingHeader] = new JsonFormat[GreetingHeader] {
-      |  override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): GreetingHeader = {
+      |trait GreetingHeaderFormats { self: java.util.DateFormats with sjsonnew.BasicJsonProtocol with generated.PriorityLevelFormats =>
+      |implicit lazy val GreetingHeaderFormat: JsonFormat[com.example.GreetingHeader] = new JsonFormat[com.example.GreetingHeader] {
+      |  override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): com.example.GreetingHeader = {
       |    jsOpt match {
       |      case Some(js) =>
       |      unbuilder.beginObject(js)
@@ -749,12 +755,12 @@ object NewSchema {
       |      val priority = unbuilder.readField[com.example.PriorityLevel]("priority")
       |      val author = unbuilder.readField[String]("author")
       |      unbuilder.endObject()
-      |      new GreetingHeader(created, priority, author)
+      |      new com.example.GreetingHeader(created, priority, author)
       |      case None =>
       |      deserializationError("Expected JsObject but found None")
       |    }
       |  }
-      |  override def write[J](obj: GreetingHeader, builder: Builder[J]): Unit = {
+      |  override def write[J](obj: com.example.GreetingHeader, builder: Builder[J]): Unit = {
       |    builder.beginObject()
       |    builder.addField("created", obj.created)
       |    builder.addField("priority", obj.priority)
@@ -763,32 +769,34 @@ object NewSchema {
       |  }
       |}
       |}
+      |package generated
       |import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
       |trait PriorityLevelFormats { self: sjsonnew.BasicJsonProtocol =>
-      |implicit lazy val PriorityLevelFormat: JsonFormat[PriorityLevel] = new JsonFormat[PriorityLevel] {
-      |  override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): PriorityLevel = {
+      |implicit lazy val PriorityLevelFormat: JsonFormat[com.example.PriorityLevel] = new JsonFormat[com.example.PriorityLevel] {
+      |  override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): com.example.PriorityLevel = {
       |    jsOpt match {
       |      case Some(js) =>
       |      unbuilder.readString(js) match {
-      |        case "Low" => PriorityLevel.Low
-      |        case "Medium" => PriorityLevel.Medium
-      |        case "High" => PriorityLevel.High
+      |        case "Low" => com.example.PriorityLevel.Low
+      |        case "Medium" => com.example.PriorityLevel.Medium
+      |        case "High" => com.example.PriorityLevel.High
       |      }
       |      case None =>
       |      deserializationError("Expected JsString but found None")
       |    }
       |  }
-      |  override def write[J](obj: PriorityLevel, builder: Builder[J]): Unit = {
+      |  override def write[J](obj: com.example.PriorityLevel, builder: Builder[J]): Unit = {
       |    val str = obj match {
-      |      case PriorityLevel.Low => "Low"
-      |      case PriorityLevel.Medium => "Medium"
-      |      case PriorityLevel.High => "High"
+      |      case com.example.PriorityLevel.Low => "Low"
+      |      case com.example.PriorityLevel.Medium => "Medium"
+      |      case com.example.PriorityLevel.High => "High"
       |    }
       |    builder.writeString(str)
       |  }
       |}
       |}
-      |trait CustomProtcol extends com.example.GreetingsFormats with com.example.GreetingHeaderFormats with com.example.PriorityLevelFormats with java.util.DateFormats with com.example.GreetingWithAttachmentsFormats with java.io.FileFormats with com.example.SimpleGreetingFormats with sjsonnew.BasicJsonProtocol
+      |package generated
+      |trait CustomProtcol extends generated.GreetingsFormats with generated.GreetingHeaderFormats with generated.PriorityLevelFormats with java.util.DateFormats with generated.GreetingWithAttachmentsFormats with java.io.FileFormats with generated.SimpleGreetingFormats with sjsonnew.BasicJsonProtocol
       |object CustomProtcol extends CustomProtcol""".stripMargin
 
 

--- a/plugin/src/main/scala/Plugin.scala
+++ b/plugin/src/main/scala/Plugin.scala
@@ -18,7 +18,6 @@ object DatatypePlugin extends AutoPlugin {
     val datatypeScalaFileNames = settingKey[Definition => File]("Mapping from `Definition` to file for Scala generator.")
     val datatypeScalaSealProtocols = settingKey[Boolean]("Seal abstract classes representing `interface`s in Scala.")
     val datatypeProtocolName = settingKey[Option[String]]("Name of the full protocol object.")
-    val datatypeCodecNamespace = settingKey[Option[String]]("Package that holds the full codec object.")
     val datatypeCodecParents = settingKey[List[String]]("Parents to add all o of the codec object.")
     val datatypeInstantiateJavaLazy = settingKey[String => String]("Function that instantiate a lazy expression from an expression in Java.")
     val datatypeFormatsForType = settingKey[TpeRef => List[String]]("Function that maps types to the list of required codecs for them.")
@@ -41,7 +40,6 @@ object DatatypePlugin extends AutoPlugin {
       // will create a separate file for every `Definition`.
       datatypeScalaSealProtocols in generateDatatypes := false,
       datatypeProtocolName in generateDatatypes := Some("CustomProtocol"),
-      datatypeCodecNamespace in generateDatatypes := None,
       datatypeCodecParents in generateDatatypes := Nil,
       datatypeInstantiateJavaLazy in generateDatatypes := { (e: String) => s"xsbti.SafeLazy($e)" },
       datatypeFormatsForType in generateDatatypes := CodecCodeGen.formatsForType,
@@ -54,7 +52,6 @@ object DatatypePlugin extends AutoPlugin {
           (datatypeScalaFileNames in generateDatatypes).value,
           (datatypeScalaSealProtocols in generateDatatypes).value,
           (datatypeProtocolName in generateDatatypes).value,
-          (datatypeCodecNamespace in generateDatatypes).value,
           (datatypeCodecParents in generateDatatypes).value,
           (datatypeInstantiateJavaLazy in generateDatatypes).value,
           (datatypeFormatsForType in generateDatatypes).value,
@@ -89,14 +86,6 @@ object DatatypePlugin extends AutoPlugin {
 }
 
 object Generate {
-
-  private def codecFileName(genScalaFileName: Definition => File): Definition => File = d => {
-    val original = genScalaFileName(d)
-    val parent = original.getParentFile
-    parent / "serialization" / original.getName
-  }
-
-
   private def generate(createDatatypes: Boolean,
     createCodecs: Boolean,
     definitions: Array[File],
@@ -105,41 +94,45 @@ object Generate {
     scalaFileNames: Definition => File,
     scalaSealProtocols: Boolean,
     protocolName: Option[String],
-    codecNamespace: Option[String],
     codecParents: List[String],
     instantiateJavaLazy: String => String,
     formatsForType: TpeRef => List[String],
     log: Logger): Seq[File] = {
-    val input = definitions flatMap (f => Schema.parse(IO read f).definitions)
-    val fullSchema = Schema(input.toList)
-
+    val input = definitions.toList map (f => Schema.parse(IO read f))
+    // val fullSchema = Schema(input flatMap {_.definitions}, None, None)
     val generator = new MixedCodeGen(javaLazy, scalaFileNames, scalaSealProtocols)
-    val jsonFormatsGenerator = new CodecCodeGen(codecFileName(scalaFileNames), protocolName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType)
+    val jsonFormatsGenerator = new CodecCodeGen(protocolName, codecParents,
+      instantiateJavaLazy, formatsForType, input)
 
     val datatypes =
       if (createDatatypes) {
-        generator.generate(fullSchema).map {
-          case (file, code) =>
-            val outputFile = new File(target, "/" + file.toString)
-            IO.write(outputFile, code)
-            log.info(s"sbt-datatype created $outputFile")
+        input flatMap { s =>
+          generator.generate(s).map {
+            case (file, code) =>
+              val outputFile = new File(target, "/" + file.toString)
+              IO.write(outputFile, code)
+              log.info(s"sbt-datatype created $outputFile")
 
-            outputFile
-        }.toList
+              outputFile
+          }.toList
+        }
       } else {
         List.empty
       }
 
     val formats =
       if (createCodecs) {
-        jsonFormatsGenerator.generate(fullSchema).map {
-          case (file, code) =>
-            val outputFile = new File(target, "/" + file.toString)
-            IO.write(outputFile, code)
-            log.info(s"sbt-datatype created $outputFile")
+        input flatMap { s =>
+          jsonFormatsGenerator.generate(s).map {
+            case (file, code) =>
+              val outputFile = new File(target, "/" + file.toString)
+              IO.write(outputFile, code)
+              log.info(code)
+              log.info(s"sbt-datatype created $outputFile")
 
-            outputFile
-        }.toList
+              outputFile
+          }.toList
+        }
       } else {
         List.empty
       }
@@ -155,13 +148,12 @@ object Generate {
     scalaFileNames: Definition => File,
     scalaSealProtocols: Boolean,
     protocolName: Option[String],
-    codecNamespace: Option[String],
     codecParents: List[String],
     instantiateJavaLazy: String => String,
     formatsForType: TpeRef => List[String],
     s: TaskStreams): Seq[File] = {
     val definitions = IO listFiles base
-    def gen() = generate(createDatatypes, createCodecs, definitions, target, javaLazy, scalaFileNames, scalaSealProtocols, protocolName, codecNamespace, codecParents, instantiateJavaLazy, formatsForType, s.log)
+    def gen() = generate(createDatatypes, createCodecs, definitions, target, javaLazy, scalaFileNames, scalaSealProtocols, protocolName, codecParents, instantiateJavaLazy, formatsForType, s.log)
     val f = FileFunction.cached(s.cacheDirectory / "gen-api", FilesInfo.hash) { _ => gen().toSet } // TODO: check if output directory changed
     f(definitions.toSet).toSeq
   }

--- a/plugin/src/sbt-test/sbt-datatype/roundtrip-test/build.sbt
+++ b/plugin/src/sbt-test/sbt-datatype/roundtrip-test/build.sbt
@@ -1,19 +1,16 @@
 import sbt.datatype._
 
-name := "example"
-
-datatypeCodecNamespace in generateDatatypes in Compile := Some("com.example")
-
-datatypeFormatsForType in generateDatatypes in Compile := { tpe =>
-  val substitutions = Map("java.io.File" -> "com.example.FileFormats")
-  CodecCodeGen.removeTypeParameters(tpe) match {
-    case TpeRef(name, _, _) if substitutions contains name => substitutions(name) :: Nil
-    case                                                 _ => ((datatypeFormatsForType in generateDatatypes in Compile).value)(tpe)
-  }
-}
-
-libraryDependencies += "com.eed3si9n" %% "sjson-new-scalajson" % "0.4.0"
-
-enablePlugins(DatatypePlugin)
-
-scalacOptions += "-Xlog-implicits"
+lazy val root = (project in file(".")).
+  enablePlugins(DatatypePlugin).
+  settings(
+    name := "example",
+    datatypeFormatsForType in generateDatatypes in Compile := { tpe =>
+      val substitutions = Map("java.io.File" -> "com.foo.FileFormats")
+      CodecCodeGen.removeTypeParameters(tpe) match {
+        case TpeRef(name, _, _) if substitutions contains name => substitutions(name) :: Nil
+        case                                                 _ => ((datatypeFormatsForType in generateDatatypes in Compile).value)(tpe)
+      }
+    },
+    libraryDependencies += "com.eed3si9n" %% "sjson-new-scalajson" % "0.4.0"
+    // scalacOptions += "-Xlog-implicits"
+  )

--- a/plugin/src/sbt-test/sbt-datatype/roundtrip-test/src/main/datatype/greeting.json
+++ b/plugin/src/sbt-test/sbt-datatype/roundtrip-test/src/main/datatype/greeting.json
@@ -1,5 +1,6 @@
 {
 	"codecNamespace": "generated",
+	"fullCodec": "CustomProtocol",
 	"types": [
 		{
 			"name": "Greeting",

--- a/plugin/src/sbt-test/sbt-datatype/roundtrip-test/src/main/datatype/greeting.json
+++ b/plugin/src/sbt-test/sbt-datatype/roundtrip-test/src/main/datatype/greeting.json
@@ -1,4 +1,5 @@
 {
+	"codecNamespace": "generated",
 	"types": [
 		{
 			"name": "Greeting",

--- a/plugin/src/sbt-test/sbt-datatype/roundtrip-test/src/main/scala/com/foo/Example.scala
+++ b/plugin/src/sbt-test/sbt-datatype/roundtrip-test/src/main/scala/com/foo/Example.scala
@@ -1,11 +1,12 @@
-package com.example
+package com.foo
 
 import sjsonnew.JsonFormat
 import sjsonnew.support.scalajson.unsafe.Converter
-import interfaces.Greeting
+import com.example.interfaces.Greeting
+import com.example._
 
 object Example extends App {
-  import CustomProtocol._
+  import generated.CustomProtocol._
   val g0: Greeting = new SimpleGreeting("Hello")
   val g1: Greeting = new SimpleGreeting("Hello", 0)
   val g21: Greeting = new GreetingWithAttachments(Array.empty, "Hello")

--- a/plugin/src/sbt-test/sbt-datatype/roundtrip-test/src/main/scala/com/foo/FileFormats.scala
+++ b/plugin/src/sbt-test/sbt-datatype/roundtrip-test/src/main/scala/com/foo/FileFormats.scala
@@ -1,4 +1,4 @@
-package com.example
+package com.foo
 
 import java.io.File
 

--- a/plugin/src/sbt-test/sbt-datatype/roundtrip-test/test
+++ b/plugin/src/sbt-test/sbt-datatype/roundtrip-test/test
@@ -1,2 +1,5 @@
 > compile
+
+$ exists target/scala-2.10/src_managed/main/generated/CustomProtocol.scala
+
 > run


### PR DESCRIPTION
move codecNamespace to the schema file

Instead of specifying codecNamespace from the plugin, this moves the
specification to the schema file.
This allows each schema file to specify different package name.
In addition fully qualified names are used everywhere to fix bugs
around how formats are referenced.

- move fullCodec setting into schema
- rename datatypeScalaSealProtocols to datatypeScalaSealInterface
