### PR TITLE
enum-related renaming

### DIFF
--- a/library/src/main/scala/SchemaData.scala
+++ b/library/src/main/scala/SchemaData.scala
@@ -75,9 +75,9 @@ sealed trait ClassLike extends Definition {
 object Definition extends Parser[Definition] {
   override def parse(json: JValue): Definition = {
     json -> "type" match {
-      case "interface"   => Interface.parse(json)
-      case "record"      => Record.parse(json)
-      case "enumeration" => Enumeration.parse(json)
+      case "interface"            => Interface.parse(json)
+      case "record"               => Record.parse(json)
+      case "enum" | "enumeration" => Enumeration.parse(json)
       case other         => sys.error(s"Invalid type: $other")
     }
   }
@@ -166,7 +166,7 @@ object Record extends Parser[Record] {
  *                      "target": ("Scala" | "Java" | "Mixed")
  *                   (, "namespace": string constant)?
  *                   (, "doc": string constant)?
- *                   (, "types": [ EnumerationValue* ])? }
+ *                   (, "symbols": [ EnumerationValue* ])? }
  */
 case class Enumeration(name: String,
   targetLang: String,
@@ -182,7 +182,7 @@ object Enumeration extends Parser[Enumeration] {
       json ->? "namespace",
       json ->? "since" map VersionNumber.apply getOrElse emptyVersion,
       json multiLineOpt "doc" getOrElse Nil,
-      json ->* "types" map EnumerationValue.parse)
+      json ->* "symbols" map EnumerationValue.parse)
 }
 
 /**

--- a/library/src/test/scala/JavaCodeGenSpec.scala
+++ b/library/src/test/scala/JavaCodeGenSpec.scala
@@ -14,7 +14,7 @@ class JavaCodeGenSpec extends GCodeGenSpec("Java") {
     code.head._2.unindent must containTheSameElementsAs(
       """/** Example of simple enumeration */
         |public enum simpleEnumerationExample {
-        |    /** First type */
+        |    /** First symbol */
         |    first,
         |    second
         |}""".stripMargin.unindent)

--- a/library/src/test/scala/ScalaCodeGenSpec.scala
+++ b/library/src/test/scala/ScalaCodeGenSpec.scala
@@ -20,7 +20,7 @@ class ScalaCodeGenSpec extends GCodeGenSpec("Scala") {
       """/** Example of simple enumeration */
         |sealed abstract class simpleEnumerationExample extends Serializable
         |object simpleEnumerationExample {
-        |  /** First type */
+        |  /** First symbol */
         |  case object first extends simpleEnumerationExample
         |
         |  case object second extends simpleEnumerationExample

--- a/library/src/test/scala/SchemaExample.scala
+++ b/library/src/test/scala/SchemaExample.scala
@@ -129,7 +129,7 @@ object NewSchema {
   "symbols": [
     {
       "name": "first",
-      "doc": "First type"
+      "doc": "First symbol"
     },
     "second"
   ]

--- a/library/src/test/scala/SchemaExample.scala
+++ b/library/src/test/scala/SchemaExample.scala
@@ -124,9 +124,9 @@ object NewSchema {
   val simpleEnumerationExample = """{
   "name": "simpleEnumerationExample",
   "target": "Scala",
-  "type": "enumeration",
+  "type": "enum",
   "doc": "Example of simple enumeration",
-  "types": [
+  "symbols": [
     {
       "name": "first",
       "doc": "First type"
@@ -349,7 +349,7 @@ object NewSchema {
       "type": "enumeration",
       "doc": "Priority levels",
 
-      "types": [
+      "symbols": [
         "Low",
         {
           "name": "Medium",

--- a/library/src/test/scala/SchemaSpec.scala
+++ b/library/src/test/scala/SchemaSpec.scala
@@ -171,7 +171,7 @@ class SchemaSpec extends Specification {
         (namespace must_== None) and
         (doc must_== List("Example of simple enumeration")) and
         (values must haveSize(2)) and
-        (values(0) must_== EnumerationValue("first", List("First type"))) and
+        (values(0) must_== EnumerationValue("first", List("First symbol"))) and
         (values(1) must_== EnumerationValue("second", Nil))
     }
   }

--- a/notes/0.2.1.markdown
+++ b/notes/0.2.1.markdown
@@ -4,7 +4,7 @@
 - The `protocol` type, which used to generate abstract classes, is renamed to `interface` [#19][19] by [@eed3si9n][@eed3si9n]
 - The `enumeration` type is renamed to `enum`, and the list of values are now called `symbols` (instead of `types`).
 
-### enhacements
+### enhancements
 
 - An interface now supports `methods` list. [#14][14] by [@Duhemm][@Duhemm]
 - Optional type support. See below.

--- a/notes/0.2.1.markdown
+++ b/notes/0.2.1.markdown
@@ -1,12 +1,18 @@
 
-### interface
+### breaking changes
 
-In sbt-datatype 0.2.1 the `protocol` type, which generates abstract class, is renamed to `interface`.
-It supports `methods` list as well as `fields`. [#14][14] by [@Duhemm][@Duhemm]/[#19][19] by [@eed3si9n][@eed3si9n]
+- The `protocol` type, which used to generate abstract classes, is renamed to `interface` [#19][19] by [@eed3si9n][@eed3si9n]
+- The `enumeration` type is renamed to `enum`, and the list of values are now called `symbols` (instead of `types`).
+
+### enhacements
+
+- An interface now supports `methods` list. [#14][14] by [@Duhemm][@Duhemm]
+- Optional type support. See below.
+- JSON codec generation. See below.
 
 ### optional
 
-Type can now be optional by adding `?` at the end:
+sbt-datatype 0.2.1 adds support for optional types. Adding `?` at the end of a type name:
 
     {
       "types": [{
@@ -24,6 +30,14 @@ Type can now be optional by adding `?` at the end:
 
 sbt-datatype 0.2.1 adds a new auto plugin `JsonCodecPlugin`, which generates JSON codec traits for [sjson-new][1].
 Using the codecs, you can define a JSON protocol stack and convert the generated datatypes into JSON.
+
+    {
+      "codecNamespace": "com.example.codec",
+      "fullCodec": "CustomProtocol",
+      "types": [....]
+    }
+
+This will generate `JsonFormat` traits under `com.example.codec` package.
 
   [14]: https://github.com/sbt/sbt-datatype/pull/14
   [19]: https://github.com/sbt/sbt-datatype/pull/19

--- a/plugin/src/sbt-test/sbt-datatype/growable-schema-java/changes/person-2.json
+++ b/plugin/src/sbt-test/sbt-datatype/growable-schema-java/changes/person-2.json
@@ -28,8 +28,8 @@
 			"name": "Gender",
 			"namespace": "com.example",
 			"target": "Java",
-			"type": "enumeration",
-			"types": [
+			"type": "enum",
+			"symbols": [
 				"Unknown",
 				"Male",
 				"Female"

--- a/plugin/src/sbt-test/sbt-datatype/growable-schema-scala/changes/person-2.json
+++ b/plugin/src/sbt-test/sbt-datatype/growable-schema-scala/changes/person-2.json
@@ -28,8 +28,8 @@
 			"name": "Gender",
 			"namespace": "com.example",
 			"target": "Scala",
-			"type": "enumeration",
-			"types": [
+			"type": "enum",
+			"symbols": [
 				"Unknown",
 				"Male",
 				"Female"


### PR DESCRIPTION
Similar to Avro, enumeration is renamed to enum.
Symbol lists are renamed from types to symbols.