### PR TITLE
"methods" is renamed to "messages"

### DIFF
--- a/library/src/main/scala/SchemaData.scala
+++ b/library/src/main/scala/SchemaData.scala
@@ -75,9 +75,9 @@ sealed trait ClassLike extends Definition {
 object Definition extends Parser[Definition] {
   override def parse(json: JValue): Definition = {
     json -> "type" match {
-      case "interface"   => Interface.parse(json)
-      case "record"      => Record.parse(json)
-      case "enumeration" => Enumeration.parse(json)
+      case "interface"            => Interface.parse(json)
+      case "record"               => Record.parse(json)
+      case "enum" | "enumeration" => Enumeration.parse(json)
       case other         => sys.error(s"Invalid type: $other")
     }
   }
@@ -166,7 +166,7 @@ object Record extends Parser[Record] {
  *                      "target": ("Scala" | "Java" | "Mixed")
  *                   (, "namespace": string constant)?
  *                   (, "doc": string constant)?
- *                   (, "types": [ EnumerationValue* ])? }
+ *                   (, "symbols": [ EnumerationValue* ])? }
  */
 case class Enumeration(name: String,
   targetLang: String,
@@ -182,7 +182,7 @@ object Enumeration extends Parser[Enumeration] {
       json ->? "namespace",
       json ->? "since" map VersionNumber.apply getOrElse emptyVersion,
       json multiLineOpt "doc" getOrElse Nil,
-      json ->* "types" map EnumerationValue.parse)
+      json ->* "symbols" map EnumerationValue.parse)
 }
 
 /**

--- a/library/src/test/scala/CodeGenSpec.scala
+++ b/library/src/test/scala/CodeGenSpec.scala
@@ -23,7 +23,7 @@ abstract class GCodeGenSpec(language: String) extends Specification {
       generate a simple interface                $interfaceGenerateSimple
       generate a simple interface with one child $interfaceGenerateOneChild
       generate nested interfaces                 $interfaceGenerateNested
-      generate abstract methods                  $interfaceGenerateAbstractMethods
+      generate messages                          $interfaceGenerateMessages
 
     generate(Record) should
       generate a simple record                   $recordGenerateSimple
@@ -41,7 +41,7 @@ abstract class GCodeGenSpec(language: String) extends Specification {
   def interfaceGenerateSimple: MatchResult[_]
   def interfaceGenerateOneChild: MatchResult[_]
   def interfaceGenerateNested: MatchResult[_]
-  def interfaceGenerateAbstractMethods: MatchResult[_]
+  def interfaceGenerateMessages: MatchResult[_]
   def recordGenerateSimple: MatchResult[_]
   def schemaGenerateComplete: MatchResult[_]
   def schemaGenerateCompletePlusIndent: MatchResult[_]

--- a/library/src/test/scala/CodecCodeGenSpec.scala
+++ b/library/src/test/scala/CodecCodeGenSpec.scala
@@ -139,7 +139,7 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
         |}""".stripMargin.unindent))
   }
 
-  def interfaceGenerateAbstractMethods = {
+  def interfaceGenerateMessages = {
     val schema = Schema parse generateArgDocExample
     val gen = new CodecCodeGen(codecParents, instantiateJavaLazy, javaOption, scalaArray, formatsForType, schema :: Nil)
     val code = gen generate schema

--- a/library/src/test/scala/JavaCodeGenSpec.scala
+++ b/library/src/test/scala/JavaCodeGenSpec.scala
@@ -181,7 +181,7 @@ class JavaCodeGenSpec extends GCodeGenSpec("Java") {
     )
   }
 
-  override def interfaceGenerateAbstractMethods = {
+  override def interfaceGenerateMessages = {
     val schema = Schema parse generateArgDocExample
     val code = new JavaCodeGen("com.example.MyLazy", "com.example.MyOption") generate schema
 
@@ -199,13 +199,13 @@ class JavaCodeGenSpec extends GCodeGenSpec("Java") {
             |        return this.field;
             |    }
             |    /**
-            |     * A very simple example of abstract method.
-            |     * Abstract methods can only appear in interface definitions.
-            |     * @param arg0 The first argument of the method.
+            |     * A very simple example of a message.
+            |     * Messages can only appear in interface definitions.
+            |     * @param arg0 The first argument of the message.
             |                   Make sure it is awesome.
             |     * @param arg1 This argument is not important, so it gets single line doc.
             |     */
-            |    public abstract int[] methodExample(com.example.MyLazy<int[]> arg0,boolean arg1);
+            |    public abstract int[] messageExample(com.example.MyLazy<int[]> arg0,boolean arg1);
             |    public boolean equals(Object obj) {
             |        if (this == obj) {
             |            return true;

--- a/library/src/test/scala/JavaCodeGenSpec.scala
+++ b/library/src/test/scala/JavaCodeGenSpec.scala
@@ -14,7 +14,7 @@ class JavaCodeGenSpec extends GCodeGenSpec("Java") {
     code.head._2.unindent must containTheSameElementsAs(
       """/** Example of simple enumeration */
         |public enum simpleEnumerationExample {
-        |    /** First type */
+        |    /** First symbol */
         |    first,
         |    second
         |}""".stripMargin.unindent)

--- a/library/src/test/scala/ScalaCodeGenSpec.scala
+++ b/library/src/test/scala/ScalaCodeGenSpec.scala
@@ -20,7 +20,7 @@ class ScalaCodeGenSpec extends GCodeGenSpec("Scala") {
       """/** Example of simple enumeration */
         |sealed abstract class simpleEnumerationExample extends Serializable
         |object simpleEnumerationExample {
-        |  /** First type */
+        |  /** First symbol */
         |  case object first extends simpleEnumerationExample
         |
         |  case object second extends simpleEnumerationExample

--- a/library/src/test/scala/ScalaCodeGenSpec.scala
+++ b/library/src/test/scala/ScalaCodeGenSpec.scala
@@ -131,7 +131,7 @@ class ScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |}""".stripMargin.unindent)
   }
 
-  override def interfaceGenerateAbstractMethods = {
+  override def interfaceGenerateMessages = {
     val schema = Schema parse generateArgDocExample
     val code = new ScalaCodeGen(scalaArray, genFileName, sealProtocols = false) generate schema
 
@@ -140,13 +140,13 @@ class ScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |  /** I'm a field. */
         |  val field: Int) extends Serializable {
         |  /**
-        |   * A very simple example of abstract method.
-        |   * Abstract methods can only appear in interface definitions.
-        |   * @param arg0 The first argument of the method.
+        |   * A very simple example of a message.
+        |   * Messages can only appear in interface definitions.
+        |   * @param arg0 The first argument of the message.
         |                 Make sure it is awesome.
         |   * @param arg1 This argument is not important, so it gets single line doc.
         |   */
-        |  def methodExample(arg0: => Vector[Int], arg1: Boolean): Vector[Int]
+        |  def messageExample(arg0: => Vector[Int], arg1: Boolean): Vector[Int]
         |  override def equals(o: Any): Boolean = o match {
         |    case x: generateArgDocExample => (this.field == x.field)
         |    case _ => false

--- a/library/src/test/scala/SchemaExample.scala
+++ b/library/src/test/scala/SchemaExample.scala
@@ -129,7 +129,7 @@ object NewSchema {
   "symbols": [
     {
       "name": "first",
-      "doc": "First type"
+      "doc": "First symbol"
     },
     "second"
   ]

--- a/library/src/test/scala/SchemaExample.scala
+++ b/library/src/test/scala/SchemaExample.scala
@@ -143,11 +143,11 @@ object NewSchema {
   "default": "2 + 2"
 }"""
 
-  val abstractMethodExample = """{
-  "name": "abstractMethodExample",
-  "doc": "Example of abstract method",
-  "type": "type",
-  "args": [
+  val messageExample = """{
+  "name": "messageExample",
+  "doc": "Example of a message",
+  "response": "int",
+  "request": [
     {
       "name": "arg0",
       "type": "type2"
@@ -232,20 +232,20 @@ object NewSchema {
           "doc": "I'm a field."
         }
       ],
-      "methods": [
+      "messages": [
         {
-          "name": "methodExample",
+          "name": "messageExample",
           "doc": [
-            "A very simple example of abstract method.",
-            "Abstract methods can only appear in interface definitions."
+            "A very simple example of a message.",
+            "Messages can only appear in interface definitions."
           ],
-          "type": "int*",
-          "args": [
+          "response": "int*",
+          "request": [
             {
               "name": "arg0",
               "type": "lazy int*",
               "doc": [
-                "The first argument of the method.",
+                "The first argument of the message.",
                 "Make sure it is awesome."
               ]
             },

--- a/library/src/test/scala/SchemaExample.scala
+++ b/library/src/test/scala/SchemaExample.scala
@@ -124,9 +124,9 @@ object NewSchema {
   val simpleEnumerationExample = """{
   "name": "simpleEnumerationExample",
   "target": "Scala",
-  "type": "enumeration",
+  "type": "enum",
   "doc": "Example of simple enumeration",
-  "types": [
+  "symbols": [
     {
       "name": "first",
       "doc": "First type"
@@ -349,7 +349,7 @@ object NewSchema {
       "type": "enumeration",
       "doc": "Priority levels",
 
-      "types": [
+      "symbols": [
         "Low",
         {
           "name": "Medium",

--- a/library/src/test/scala/SchemaSpec.scala
+++ b/library/src/test/scala/SchemaSpec.scala
@@ -171,7 +171,7 @@ class SchemaSpec extends Specification {
         (namespace must_== None) and
         (doc must_== List("Example of simple enumeration")) and
         (values must haveSize(2)) and
-        (values(0) must_== EnumerationValue("first", List("First type"))) and
+        (values(0) must_== EnumerationValue("first", List("First symbol"))) and
         (values(1) must_== EnumerationValue("second", Nil))
     }
   }

--- a/library/src/test/scala/SchemaSpec.scala
+++ b/library/src/test/scala/SchemaSpec.scala
@@ -32,6 +32,9 @@ class SchemaSpec extends Specification {
     Enumeration.parse should
       parse simple enumeration                   $enumerationParseSimple
 
+    Message.parse should
+      parse                                      $messageParse
+
     Field.parse should
       parse                                      $fieldParse
       parse multiline doc comments               $multiLineDoc
@@ -188,13 +191,13 @@ class SchemaSpec extends Specification {
 
   }
 
-  def abstractMethodParse = {
-    AbstractMethod parse abstractMethodExample match {
-      case AbstractMethod(name, doc, retTpe, args) =>
-        (name must_== "abstractMethodExample") and
-        (doc must_== List("Example of abstract method")) and
-        (retTpe must_== TpeRef("type", false, false, false)) and
-        (args must_== List(Arg("arg0", Nil, TpeRef("type2", false, false, false))))
+  def messageParse = {
+    Message parse messageExample match {
+      case Message(name, doc, retTpe, request) =>
+        (name must_== "messageExample") and
+        (doc must_== List("Example of a message")) and
+        (retTpe must_== TpeRef("int", false, false, false)) and
+        (request must_== List(Request("arg0", Nil, TpeRef("type2", false, false, false))))
     }
   }
 

--- a/notes/0.2.1.markdown
+++ b/notes/0.2.1.markdown
@@ -6,9 +6,9 @@
 
 ### enhancements
 
-- An interface now supports `methods` list. [#14][14] by [@Duhemm][@Duhemm]
 - Optional type support. See below.
 - JSON codec generation. See below.
+- An interface now supports `messages` list, which generates abstract methods. [#14][14] by [@Duhemm][@Duhemm]
 
 ### optional
 
@@ -26,6 +26,8 @@ sbt-datatype 0.2.1 adds support for optional types. Adding `?` at the end of a t
       }]
     }
 
+[#22][22] by [@eed3si9n][@eed3si9n]
+
 ### JsonCodecPlugin
 
 sbt-datatype 0.2.1 adds a new auto plugin `JsonCodecPlugin`, which generates JSON codec traits for [sjson-new][1].
@@ -39,8 +41,12 @@ Using the codecs, you can define a JSON protocol stack and convert the generated
 
 This will generate `JsonFormat` traits under `com.example.codec` package.
 
+[#15][15] etc by [@Duhemm][@Duhemm]/[@eed3si9n][@eed3si9n]
+
   [14]: https://github.com/sbt/sbt-datatype/pull/14
+  [15]: https://github.com/sbt/sbt-datatype/pull/15
   [19]: https://github.com/sbt/sbt-datatype/pull/19
+  [22]: https://github.com/sbt/sbt-datatype/pull/22
   [@eed3si9n]: https://github.com/eed3si9n
   [@jsuereth]: https://github.com/jsuereth
   [@dwijnand]: http://github.com/dwijnand

--- a/notes/0.2.1.markdown
+++ b/notes/0.2.1.markdown
@@ -4,7 +4,7 @@
 - The `protocol` type, which used to generate abstract classes, is renamed to `interface` [#19][19] by [@eed3si9n][@eed3si9n]
 - The `enumeration` type is renamed to `enum`, and the list of values are now called `symbols` (instead of `types`).
 
-### enhacements
+### enhancements
 
 - An interface now supports `methods` list. [#14][14] by [@Duhemm][@Duhemm]
 - Optional type support. See below.

--- a/notes/0.2.1.markdown
+++ b/notes/0.2.1.markdown
@@ -1,12 +1,18 @@
 
-### interface
+### breaking changes
 
-In sbt-datatype 0.2.1 the `protocol` type, which generates abstract class, is renamed to `interface`.
-It supports `methods` list as well as `fields`. [#14][14] by [@Duhemm][@Duhemm]/[#19][19] by [@eed3si9n][@eed3si9n]
+- The `protocol` type, which used to generate abstract classes, is renamed to `interface` [#19][19] by [@eed3si9n][@eed3si9n]
+- The `enumeration` type is renamed to `enum`, and the list of values are now called `symbols` (instead of `types`).
+
+### enhacements
+
+- An interface now supports `methods` list. [#14][14] by [@Duhemm][@Duhemm]
+- Optional type support. See below.
+- JSON codec generation. See below.
 
 ### optional
 
-Type can now be optional by adding `?` at the end:
+sbt-datatype 0.2.1 adds support for optional types. Adding `?` at the end of a type name:
 
     {
       "types": [{
@@ -24,6 +30,14 @@ Type can now be optional by adding `?` at the end:
 
 sbt-datatype 0.2.1 adds a new auto plugin `JsonCodecPlugin`, which generates JSON codec traits for [sjson-new][1].
 Using the codecs, you can define a JSON protocol stack and convert the generated datatypes into JSON.
+
+    {
+      "codecNamespace": "com.example.codec",
+      "fullCodec": "CustomProtocol",
+      "types": [....]
+    }
+
+This will generate `JsonFormat` traits under `com.example.codec` package.
 
   [14]: https://github.com/sbt/sbt-datatype/pull/14
   [19]: https://github.com/sbt/sbt-datatype/pull/19

--- a/plugin/src/sbt-test/sbt-datatype/growable-schema-java/changes/person-2.json
+++ b/plugin/src/sbt-test/sbt-datatype/growable-schema-java/changes/person-2.json
@@ -28,8 +28,8 @@
 			"name": "Gender",
 			"namespace": "com.example",
 			"target": "Java",
-			"type": "enumeration",
-			"types": [
+			"type": "enum",
+			"symbols": [
 				"Unknown",
 				"Male",
 				"Female"

--- a/plugin/src/sbt-test/sbt-datatype/growable-schema-scala/changes/person-2.json
+++ b/plugin/src/sbt-test/sbt-datatype/growable-schema-scala/changes/person-2.json
@@ -28,8 +28,8 @@
 			"name": "Gender",
 			"namespace": "com.example",
 			"target": "Scala",
-			"type": "enumeration",
-			"types": [
+			"type": "enum",
+			"symbols": [
 				"Unknown",
 				"Male",
 				"Female"


### PR DESCRIPTION
Avro calls the list of abstract methods "messages." I think it makes sense since we don't support the full methods.
