### PR TITLE
Fixes code generation for `interface`'s `toString`.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ lazy val commonSettings = Seq(
 
 lazy val pluginSettings = commonSettings ++ Seq(
   bintrayPackage := "sbt-datatype",
-  version := "0.2.2",
+  version := "0.2.3-SNAPSHOT",
   sbtPlugin := true
 )
 

--- a/library/src/main/scala/ScalaCodeGen.scala
+++ b/library/src/main/scala/ScalaCodeGen.scala
@@ -207,6 +207,10 @@ class ScalaCodeGen(scalaArray: String, genFile: Definition => File, sealProtocol
       s"""override def toString: String = {
          |  super.toString // Avoid evaluating lazy members in toString to avoid circularity.
          |}""".stripMargin
+    } else if (allFields.isEmpty) {
+      s"""override def toString: String = {
+         |  "${cl.name}()"
+         |}""".stripMargin
     } else {
       val fieldsToString =
         allFields.map(_.name).mkString(" + ", """ + ", " + """, " + ")

--- a/library/src/test/scala/ScalaCodeGenSpec.scala
+++ b/library/src/test/scala/ScalaCodeGenSpec.scala
@@ -114,7 +114,7 @@ class ScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |    17
         |  }
         |  override def toString: String = {
-        |    "nestedProtocolExample(" +  + ")"
+        |    "nestedProtocolExample()"
         |  }
         |}
         |sealed abstract class nestedProtocol() extends nestedProtocolExample() {
@@ -126,7 +126,7 @@ class ScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |    17
         |  }
         |  override def toString: String = {
-        |    "nestedProtocol(" +  + ")"
+        |    "nestedProtocol()"
         |  }
         |}""".stripMargin.unindent)
   }

--- a/notes/0.2.3.markdown
+++ b/notes/0.2.3.markdown
@@ -1,0 +1,4 @@
+
+### bug fixes
+
+- Fixes code generation for `interface`'s `toString`.

--- a/plugin/src/sbt-test/sbt-datatype/simple-new-schema/src/main/datatype/schema.json
+++ b/plugin/src/sbt-test/sbt-datatype/simple-new-schema/src/main/datatype/schema.json
@@ -1,20 +1,26 @@
 {
-	"types": [
-		{
-			"type": "record",
-			"namespace": "com.example",
-			"target": "Scala",
-			"name": "Person",
-			"fields": [
-				{
-					"name": "name",
-					"type": "String"
-				},
-				{
-					"name": "age",
-					"type": "int"
-				}
-			]
-		}
-	]
+  "types": [
+    {
+      "type": "record",
+      "namespace": "com.example",
+      "target": "Scala",
+      "name": "Person",
+      "fields": [
+        {
+          "name": "name",
+          "type": "String"
+        },
+        {
+          "name": "age",
+          "type": "int"
+        }
+      ]
+    },
+    {
+      "type": "interface",
+      "namespace": "com.example",
+      "target": "Scala",
+      "name": "emptyInterfaceExample"
+    }
+  ]
 }


### PR DESCRIPTION
When the interface is empty, it was producing junk toString like this:

```
"nestedProtocol(" +  + ")"
```
