### PR TITLE
Generate codec for recursive structures

### DIFF
--- a/library/src/main/scala/CodecCodeGen.scala
+++ b/library/src/main/scala/CodecCodeGen.scala
@@ -224,7 +224,7 @@ class CodecCodeGen(codecParents: List[String],
         case _            => getRequiredFormats(s, d, superFields)
       })
     }: _*)
-    val xs = sbt.Dag.topologicalSort[String](seedFormats) { s => dependencies.get(s).getOrElse(Nil) }
+    val xs = sbt.Dag.topologicalSortUnchecked[String](seedFormats) { s => dependencies.get(s).getOrElse(Nil) }
     xs.reverse
   }
 

--- a/library/src/test/scala/CodecCodeGenSpec.scala
+++ b/library/src/test/scala/CodecCodeGenSpec.scala
@@ -98,7 +98,7 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
         |// DO NOT EDIT MANUALLY
         |package generated
         |import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
-        |trait OneChildInterfaceExampleFormats { self: generated.ChildRecordFormats with sjsonnew.BasicJsonProtocol =>
+        |trait OneChildInterfaceExampleFormats { self: sjsonnew.BasicJsonProtocol with generated.ChildRecordFormats =>
         |  implicit lazy val oneChildInterfaceExampleFormat: JsonFormat[_root_.oneChildInterfaceExample] = unionFormat1[_root_.oneChildInterfaceExample, _root_.childRecord]
         |}""".stripMargin.unindent)) and
     (code(new File("generated", "childRecordFormats.scala")).unindent must containTheSameElementsAs(
@@ -146,7 +146,7 @@ class CodecCodeGenSpec extends GCodeGenSpec("Codec") {
         |// DO NOT EDIT MANUALLY
         |package generated
         |import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
-        |trait NestedProtocolExampleFormats { self: generated.NestedProtocolFormats with sjsonnew.BasicJsonProtocol =>
+        |trait NestedProtocolExampleFormats { self: sjsonnew.BasicJsonProtocol with generated.NestedProtocolFormats =>
         |  implicit lazy val nestedProtocolExampleFormat: JsonFormat[_root_.nestedProtocolExample] = unionFormat1[_root_.nestedProtocolExample, _root_.nestedProtocol]
         |}""".stripMargin.unindent)) and
     (code(new File("generated", "nestedProtocolFormats.scala")).unindent must containTheSameElementsAs(

--- a/library/src/test/scala/SchemaExample.scala
+++ b/library/src/test/scala/SchemaExample.scala
@@ -849,7 +849,7 @@ public final class GreetingExtraImpl extends com.example.GreetingExtra {
 // DO NOT EDIT MANUALLY
 package generated
 import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
-trait GreetingsFormats { self: generated.GreetingHeaderFormats with generated.GreetingWithAttachmentsFormats with generated.GreetingExtraFormats with generated.GreetingExtraImplFormats with generated.SimpleGreetingFormats with sjsonnew.BasicJsonProtocol =>
+trait GreetingsFormats { self: sjsonnew.BasicJsonProtocol with generated.SimpleGreetingFormats with generated.GreetingExtraImplFormats with generated.GreetingExtraFormats with generated.GreetingWithAttachmentsFormats with generated.GreetingHeaderFormats =>
 implicit lazy val GreetingsFormat: JsonFormat[com.example.Greetings] = unionFormat3[com.example.Greetings, com.example.SimpleGreeting, com.example.GreetingExtra, com.example.GreetingWithAttachments]
 }
 /**
@@ -888,7 +888,7 @@ implicit lazy val SimpleGreetingFormat: JsonFormat[com.example.SimpleGreeting] =
 // DO NOT EDIT MANUALLY
 package generated
 import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
-trait GreetingExtraFormats { self: generated.GreetingExtraImplFormats with sjsonnew.BasicJsonProtocol with generated.GreetingHeaderFormats =>
+trait GreetingExtraFormats { self: generated.GreetingHeaderFormats with sjsonnew.BasicJsonProtocol with generated.GreetingExtraImplFormats =>
 implicit lazy val GreetingExtraFormat: JsonFormat[com.example.GreetingExtra] = unionFormat1[com.example.GreetingExtra, com.example.GreetingExtraImpl]
 }
 /**
@@ -1023,7 +1023,7 @@ implicit lazy val PriorityLevelFormat: JsonFormat[com.example.PriorityLevel] = n
 
 // DO NOT EDIT MANUALLY
 package generated
-trait CustomProtcol extends generated.GreetingsFormats with generated.GreetingHeaderFormats with generated.PriorityLevelFormats with java.util.DateFormats with generated.GreetingWithAttachmentsFormats with generated.GreetingExtraFormats with generated.GreetingExtraImplFormats with generated.SimpleGreetingFormats with sjsonnew.BasicJsonProtocol
+trait CustomProtcol extends sjsonnew.BasicJsonProtocol with generated.SimpleGreetingFormats with generated.GreetingExtraImplFormats with generated.GreetingExtraFormats with generated.GreetingWithAttachmentsFormats with java.util.DateFormats with generated.PriorityLevelFormats with generated.GreetingHeaderFormats with generated.GreetingsFormats
 object CustomProtcol extends CustomProtcol""".stripMargin
 
 

--- a/notes/0.2.5.markdown
+++ b/notes/0.2.5.markdown
@@ -1,0 +1,7 @@
+
+### bug fixes
+
+- Generate codec for recursive structures. [#35][35] by [@Duhemm][@Duhemm]
+
+  [35]: https://github.com/sbt/sbt-datatype/pull/35
+  [@Duhemm]: https://github.com/Duhemm

--- a/plugin/src/sbt-test/sbt-datatype/recursive-schema/build.sbt
+++ b/plugin/src/sbt-test/sbt-datatype/recursive-schema/build.sbt
@@ -1,0 +1,1 @@
+enablePlugins(DatatypePlugin, JsonCodecPlugin)

--- a/plugin/src/sbt-test/sbt-datatype/recursive-schema/project/plugins.sbt
+++ b/plugin/src/sbt-test/sbt-datatype/recursive-schema/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("org.scala-sbt" % "sbt-datatype" % pluginVersion)
+}

--- a/plugin/src/sbt-test/sbt-datatype/recursive-schema/src/main/datatype/recursive.json
+++ b/plugin/src/sbt-test/sbt-datatype/recursive-schema/src/main/datatype/recursive.json
@@ -1,0 +1,28 @@
+{
+  "types": [
+    {
+      "name": "Term",
+      "namespace": "expr",
+      "type": "interface",
+      "target": "Scala",
+      "types": [
+        {
+          "name": "Addition",
+          "namespace": "expr",
+          "type": "record",
+          "target": "Scala",
+          "fields": [
+            {
+              "name": "lhs",
+              "type": "expr.Term"
+            },
+            {
+              "name": "rhs",
+              "type": "expr.Term"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/plugin/src/sbt-test/sbt-datatype/recursive-schema/test
+++ b/plugin/src/sbt-test/sbt-datatype/recursive-schema/test
@@ -1,0 +1,1 @@
+> compile


### PR DESCRIPTION
`Dag.topologicalSort` checks for cycles, but certain structures may
contain cycles and still be valid. We use `Dag.topologicalSortUnchecked`,
which doesn't checks for cycle (but still works with cyclic structures),
to order the required formats rather than `Dag.topologicalSort`.

See the attached scripted test for an example of legitimate cyclic structure.