### PR TITLE
Remove public copy method.

### DIFF
--- a/library/src/main/scala/ScalaCodeGen.scala
+++ b/library/src/main/scala/ScalaCodeGen.scala
@@ -62,7 +62,7 @@ class ScalaCodeGen(scalaArray: String, genFile: Definition => File, sealProtocol
          |  ${genEquals(r, superFields)}
          |  ${genHashCode(r, superFields)}
          |  ${genToString(r, superFields, r.toStringImpl)}
-         |  ${genCopyOverloads(r, allFields) mkString EOL}
+         |  ${genCopy(r, allFields)}
          |  ${genWith(r, superFields)}
          |}
          |
@@ -279,26 +279,14 @@ class ScalaCodeGen(scalaArray: String, genFile: Definition => File, sealProtocol
 
   private def genPackage(d: Definition): String = d.namespace map (ns => s"package $ns") getOrElse ""
 
-  private def genCopyOverloads(r: Record, allFields: List[Field]) =
-    if (allFields.isEmpty) { // If there are no fields, we still need an `copy` method with an empty parameter list
-      List(s"def copy(): ${r.name} = new ${r.name}()")
-    } else {
-      perVersionNumber(r.since, allFields) { (provided, byDefault) =>
-        def genParam(f: Field) = {
-          val name = bq(f.name)
-          val tpe = genRealTpe(f.tpe, isParam = true)
-          if (byDefault.isEmpty) // when all fields are provided, then given them their default value
-            s"$name: $tpe = $name"
-          else
-            s"$name: $tpe"
-        }
-        val params = provided map genParam mkString ", "
-        val constructorCall = allFields map (f => bq(f.name)) mkString ", "
-        s"""def copy($params): ${r.name} = {
-           |  new ${r.name}($constructorCall)
-           |}""".stripMargin
-      }
-    }
+  private def genCopy(r: Record, allFields: List[Field]) = {
+    def genParam(f: Field) = s"${bq(f.name)}: ${genRealTpe(f.tpe, isParam = true)} = ${bq(f.name)}"
+    val params = allFields map genParam mkString ", "
+    val constructorCall = allFields map (f => bq(f.name)) mkString ", "
+    s"""private[this] def copy($params): ${r.name} = {
+       |  new ${r.name}($constructorCall)
+       |}""".stripMargin
+  }
 
   private def genWith(r: Record, superFields: List[Field]) = {
     def capitalize(s: String) = { val (fst, rst) = s.splitAt(1) ; fst.toUpperCase + rst }

--- a/library/src/main/scala/ScalaCodeGen.scala
+++ b/library/src/main/scala/ScalaCodeGen.scala
@@ -283,7 +283,7 @@ class ScalaCodeGen(scalaArray: String, genFile: Definition => File, sealProtocol
     def genParam(f: Field) = s"${bq(f.name)}: ${genRealTpe(f.tpe, isParam = true)} = ${bq(f.name)}"
     val params = allFields map genParam mkString ", "
     val constructorCall = allFields map (f => bq(f.name)) mkString ", "
-    s"""private[this] def copy($params): ${r.name} = {
+    s"""protected[this] def copy($params): ${r.name} = {
        |  new ${r.name}($constructorCall)
        |}""".stripMargin
   }

--- a/library/src/test/scala/ScalaCodeGenSpec.scala
+++ b/library/src/test/scala/ScalaCodeGenSpec.scala
@@ -91,7 +91,7 @@ class ScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |  override def toString: String = {
         |    "childRecord(" + field + ", " + x + ")"
         |  }
-        |  private[this] def copy(field: Int = field, x: Int = x): childRecord = {
+        |  protected[this] def copy(field: Int = field, x: Int = x): childRecord = {
         |    new childRecord(field, x)
         |  }
         |  def withField(field: Int): childRecord = {
@@ -201,7 +201,7 @@ class ScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |  override def toString: String = {
         |    "simpleRecordExample(" + field + ")"
         |  }
-        |  private[this] def copy(field: java.net.URL = field): simpleRecordExample = {
+        |  protected[this] def copy(field: java.net.URL = field): simpleRecordExample = {
         |    new simpleRecordExample(field)
         |  }
         |  def withField(field: java.net.URL): simpleRecordExample = {
@@ -233,7 +233,7 @@ class ScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |  override def toString: String = {
         |    "growableAddOneField(" + field + ")"
         |  }
-        |  private[this] def copy(field: Int = field): growableAddOneField = {
+        |  protected[this] def copy(field: Int = field): growableAddOneField = {
         |    new growableAddOneField(field)
         |  }
         |  def withField(field: Int): growableAddOneField = {
@@ -268,7 +268,7 @@ class ScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |  override def toString: String = {
         |    "Foo(" + x + ", " + y + ")"
         |  }
-        |  private[this] def copy(x: Int = x, y: Int = y): Foo = {
+        |  protected[this] def copy(x: Int = x, y: Int = y): Foo = {
         |    new Foo(x, y)
         |  }
         |  def withX(x: Int): Foo = {
@@ -313,7 +313,7 @@ class ScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |  override def toString: String = {
         |    super.toString // Avoid evaluating lazy members in toString to avoid circularity.
         |  }
-        |  private[this] def copy(simpleInteger: Int = simpleInteger, lazyInteger: => Int = lazyInteger, arrayInteger: Vector[Int] = arrayInteger, optionInteger: Option[Int] = optionInteger, lazyArrayInteger: => Vector[Int] = lazyArrayInteger, lazyOptionInteger: => Option[Int] = lazyOptionInteger): primitiveTypesExample = {
+        |  protected[this] def copy(simpleInteger: Int = simpleInteger, lazyInteger: => Int = lazyInteger, arrayInteger: Vector[Int] = arrayInteger, optionInteger: Option[Int] = optionInteger, lazyArrayInteger: => Vector[Int] = lazyArrayInteger, lazyOptionInteger: => Option[Int] = lazyOptionInteger): primitiveTypesExample = {
         |    new primitiveTypesExample(simpleInteger, lazyInteger, arrayInteger, optionInteger, lazyArrayInteger, lazyOptionInteger)
         |  }
         |  def withSimpleInteger(simpleInteger: Int): primitiveTypesExample = {
@@ -365,7 +365,7 @@ class ScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |  override def toString: String = {
         |    "primitiveTypesNoLazyExample(" + simpleInteger + ", " + arrayInteger + ")"
         |  }
-        |  private[this] def copy(simpleInteger: Int = simpleInteger, arrayInteger: Vector[Int] = arrayInteger): primitiveTypesNoLazyExample = {
+        |  protected[this] def copy(simpleInteger: Int = simpleInteger, arrayInteger: Vector[Int] = arrayInteger): primitiveTypesNoLazyExample = {
         |    new primitiveTypesNoLazyExample(simpleInteger, arrayInteger)
         |  }
         |  def withSimpleInteger(simpleInteger: Int): primitiveTypesNoLazyExample = {

--- a/library/src/test/scala/ScalaCodeGenSpec.scala
+++ b/library/src/test/scala/ScalaCodeGenSpec.scala
@@ -91,7 +91,7 @@ class ScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |  override def toString: String = {
         |    "childRecord(" + field + ", " + x + ")"
         |  }
-        |  def copy(field: Int = field, x: Int = x): childRecord = {
+        |  private[this] def copy(field: Int = field, x: Int = x): childRecord = {
         |    new childRecord(field, x)
         |  }
         |  def withField(field: Int): childRecord = {
@@ -201,7 +201,7 @@ class ScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |  override def toString: String = {
         |    "simpleRecordExample(" + field + ")"
         |  }
-        |  def copy(field: java.net.URL = field): simpleRecordExample = {
+        |  private[this] def copy(field: java.net.URL = field): simpleRecordExample = {
         |    new simpleRecordExample(field)
         |  }
         |  def withField(field: java.net.URL): simpleRecordExample = {
@@ -233,10 +233,7 @@ class ScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |  override def toString: String = {
         |    "growableAddOneField(" + field + ")"
         |  }
-        |  def copy(): growableAddOneField = {
-        |    new growableAddOneField(field)
-        |  }
-        |  def copy(field: Int = field): growableAddOneField = {
+        |  private[this] def copy(field: Int = field): growableAddOneField = {
         |    new growableAddOneField(field)
         |  }
         |  def withField(field: Int): growableAddOneField = {
@@ -271,13 +268,7 @@ class ScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |  override def toString: String = {
         |    "Foo(" + x + ", " + y + ")"
         |  }
-        |  def copy(): Foo = {
-        |    new Foo(x, y)
-        |  }
-        |  def copy(x: Int): Foo = {
-        |    new Foo(x, y)
-        |  }
-        |  def copy(x: Int = x, y: Int = y): Foo = {
+        |  private[this] def copy(x: Int = x, y: Int = y): Foo = {
         |    new Foo(x, y)
         |  }
         |  def withX(x: Int): Foo = {
@@ -322,7 +313,7 @@ class ScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |  override def toString: String = {
         |    super.toString // Avoid evaluating lazy members in toString to avoid circularity.
         |  }
-        |  def copy(simpleInteger: Int = simpleInteger, lazyInteger: => Int = lazyInteger, arrayInteger: Vector[Int] = arrayInteger, optionInteger: Option[Int] = optionInteger, lazyArrayInteger: => Vector[Int] = lazyArrayInteger, lazyOptionInteger: => Option[Int] = lazyOptionInteger): primitiveTypesExample = {
+        |  private[this] def copy(simpleInteger: Int = simpleInteger, lazyInteger: => Int = lazyInteger, arrayInteger: Vector[Int] = arrayInteger, optionInteger: Option[Int] = optionInteger, lazyArrayInteger: => Vector[Int] = lazyArrayInteger, lazyOptionInteger: => Option[Int] = lazyOptionInteger): primitiveTypesExample = {
         |    new primitiveTypesExample(simpleInteger, lazyInteger, arrayInteger, optionInteger, lazyArrayInteger, lazyOptionInteger)
         |  }
         |  def withSimpleInteger(simpleInteger: Int): primitiveTypesExample = {
@@ -374,7 +365,7 @@ class ScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |  override def toString: String = {
         |    "primitiveTypesNoLazyExample(" + simpleInteger + ", " + arrayInteger + ")"
         |  }
-        |  def copy(simpleInteger: Int = simpleInteger, arrayInteger: Vector[Int] = arrayInteger): primitiveTypesNoLazyExample = {
+        |  private[this] def copy(simpleInteger: Int = simpleInteger, arrayInteger: Vector[Int] = arrayInteger): primitiveTypesNoLazyExample = {
         |    new primitiveTypesNoLazyExample(simpleInteger, arrayInteger)
         |  }
         |  def withSimpleInteger(simpleInteger: Int): primitiveTypesNoLazyExample = {

--- a/library/src/test/scala/SchemaExample.scala
+++ b/library/src/test/scala/SchemaExample.scala
@@ -447,7 +447,7 @@ final class SimpleGreeting(
   override def toString: String = {
     super.toString // Avoid evaluating lazy members in toString to avoid circularity.
   }
-  private[this] def copy(message: => String = message, header: com.example.GreetingHeader = header): SimpleGreeting = {
+  protected[this] def copy(message: => String = message, header: com.example.GreetingHeader = header): SimpleGreeting = {
     new SimpleGreeting(message, header)
   }
   def withMessage(message: => String): SimpleGreeting = {
@@ -500,7 +500,7 @@ final class GreetingExtraImpl(
   override def toString: String = {
     return "Welcome, extra implosion!";
   }
-  private[this] def copy(message: => String = message, header: com.example.GreetingHeader = header, extra: Vector[String] = extra, x: String = x): GreetingExtraImpl = {
+  protected[this] def copy(message: => String = message, header: com.example.GreetingHeader = header, extra: Vector[String] = extra, x: String = x): GreetingExtraImpl = {
     new GreetingExtraImpl(message, header, extra, x)
   }
   def withMessage(message: => String): GreetingExtraImpl = {
@@ -539,7 +539,7 @@ final class GreetingWithAttachments(
   override def toString: String = {
     super.toString // Avoid evaluating lazy members in toString to avoid circularity.
   }
-  private[this] def copy(message: => String = message, header: com.example.GreetingHeader = header, attachments: Vector[java.io.File] = attachments): GreetingWithAttachments = {
+  protected[this] def copy(message: => String = message, header: com.example.GreetingHeader = header, attachments: Vector[java.io.File] = attachments): GreetingWithAttachments = {
     new GreetingWithAttachments(message, header, attachments)
   }
   def withMessage(message: => String): GreetingWithAttachments = {
@@ -577,7 +577,7 @@ final class GreetingHeader(
   override def toString: String = {
     super.toString // Avoid evaluating lazy members in toString to avoid circularity.
   }
-  private[this] def copy(created: => java.util.Date = created, priority: com.example.PriorityLevel = priority, author: String = author): GreetingHeader = {
+  protected[this] def copy(created: => java.util.Date = created, priority: com.example.PriorityLevel = priority, author: String = author): GreetingHeader = {
     new GreetingHeader(created, priority, author)
   }
   def withCreated(created: => java.util.Date): GreetingHeader = {

--- a/library/src/test/scala/SchemaExample.scala
+++ b/library/src/test/scala/SchemaExample.scala
@@ -447,10 +447,7 @@ final class SimpleGreeting(
   override def toString: String = {
     super.toString // Avoid evaluating lazy members in toString to avoid circularity.
   }
-  def copy(message: => String): SimpleGreeting = {
-    new SimpleGreeting(message, header)
-  }
-  def copy(message: => String = message, header: com.example.GreetingHeader = header): SimpleGreeting = {
+  private[this] def copy(message: => String = message, header: com.example.GreetingHeader = header): SimpleGreeting = {
     new SimpleGreeting(message, header)
   }
   def withMessage(message: => String): SimpleGreeting = {
@@ -503,10 +500,7 @@ final class GreetingExtraImpl(
   override def toString: String = {
     return "Welcome, extra implosion!";
   }
-  def copy(message: => String, extra: Vector[String], x: String): GreetingExtraImpl = {
-    new GreetingExtraImpl(message, header, extra, x)
-  }
-  def copy(message: => String = message, header: com.example.GreetingHeader = header, extra: Vector[String] = extra, x: String = x): GreetingExtraImpl = {
+  private[this] def copy(message: => String = message, header: com.example.GreetingHeader = header, extra: Vector[String] = extra, x: String = x): GreetingExtraImpl = {
     new GreetingExtraImpl(message, header, extra, x)
   }
   def withMessage(message: => String): GreetingExtraImpl = {
@@ -545,10 +539,7 @@ final class GreetingWithAttachments(
   override def toString: String = {
     super.toString // Avoid evaluating lazy members in toString to avoid circularity.
   }
-  def copy(message: => String, attachments: Vector[java.io.File]): GreetingWithAttachments = {
-    new GreetingWithAttachments(message, header, attachments)
-  }
-  def copy(message: => String = message, header: com.example.GreetingHeader = header, attachments: Vector[java.io.File] = attachments): GreetingWithAttachments = {
+  private[this] def copy(message: => String = message, header: com.example.GreetingHeader = header, attachments: Vector[java.io.File] = attachments): GreetingWithAttachments = {
     new GreetingWithAttachments(message, header, attachments)
   }
   def withMessage(message: => String): GreetingWithAttachments = {
@@ -586,10 +577,7 @@ final class GreetingHeader(
   override def toString: String = {
     super.toString // Avoid evaluating lazy members in toString to avoid circularity.
   }
-  def copy(created: => java.util.Date, author: String): GreetingHeader = {
-    new GreetingHeader(created, priority, author)
-  }
-  def copy(created: => java.util.Date = created, priority: com.example.PriorityLevel = priority, author: String = author): GreetingHeader = {
+  private[this] def copy(created: => java.util.Date = created, priority: com.example.PriorityLevel = priority, author: String = author): GreetingHeader = {
     new GreetingHeader(created, priority, author)
   }
   def withCreated(created: => java.util.Date): GreetingHeader = {

--- a/notes/0.2.8/no-default-arguments.markdown
+++ b/notes/0.2.8/no-default-arguments.markdown
@@ -1,0 +1,8 @@
+
+### breaking changes
+
+- Removes use of default arguments and therefore the copy overloads. [#48][48]/[#50][50] by [@dwijnand][@dwijnand]
+
+  [48]: https://github.com/sbt/sbt-datatype/issues/48
+  [50]: https://github.com/sbt/sbt-datatype/pull/50
+  [@dwijnand]: http://github.com/dwijnand


### PR DESCRIPTION
Fixes #48. Fixes #49.

Revert "Add support for public, overloaded, bincompat copy"

This reverts commit 3311302fb3d410d940a9a3384967c45c805eed1b.

Make the copy method protected[this] so it can be defined and uses in the parent